### PR TITLE
Add documentation

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -24,6 +24,7 @@ flake8
 # for building documentation
 sphinx
 sphinx_rtd_theme
+git+https://github.com/openSUSE/rstxml2docbook.git@feature/kiwi
 
 # Python static type checker
 mypy

--- a/doc/DC-keg
+++ b/doc/DC-keg
@@ -1,0 +1,8 @@
+## ----------------------------
+## Doc Config File for DAPS
+## ----------------------------
+MAIN=xml/book.xml
+ADOC_POST=yes
+ADOC_TYPE=book
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -51,7 +51,7 @@ clean:
 
 .PHONY: html
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html && cp -a source/development/schema/images $(BUILDDIR)/html/development || true
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/source/commands/keg.rst
+++ b/doc/source/commands/keg.rst
@@ -18,14 +18,17 @@ DESCRIPTION
 -----------
 
 Keg is a tool which helps to create and manage image descriptions suitable
-for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder. Its
-main use case is to keep control over a larger amount of image descriptions
-and prevent duplication of description data.
+for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder.
+While keg can be used to manage a single image definition the tool provides
+no considerable advantage in such a use case. The primary use case for keg
+are situations where many image descriptions must be managed and the
+image descriptions have considerable over lap with respect to content
+and setup.
 
 The key component for Keg is a data structure called `image definition tree`.
-This data structure contains all information to create KIWI image
-descriptions and provides data in a way that no or as little as possible
-duplication exists.
+This data structure is expected to contain all information necessary to
+create KIWI image descriptions. Keg is implemented such that data inheritance
+is possible to reduce data duplication in the `image definition tree`.
 
 Please find an implementation of an `image definition tree` with
 a focus on Public Cloud images here:

--- a/doc/source/commands/keg.rst
+++ b/doc/source/commands/keg.rst
@@ -19,7 +19,7 @@ DESCRIPTION
 
 Keg is a tool which helps to create and manage image descriptions suitable
 for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder.
-While keg can be used to manage a single image definition the tool provides
+While `keg` can be used to manage a single image definition the tool provides
 no considerable advantage in such a use case. The primary use case for keg
 are situations where many image descriptions must be managed and the
 image descriptions have considerable over lap with respect to content
@@ -48,7 +48,7 @@ OPTIONS
 
 -r RECIPES_ROOT, --recipes-root=RECIPES_ROOT
 
-  Root directory of keg recipes
+  Root directory of Keg recipes
 
 -a ADD_DATA_ROOT, --add-data-root=ADD_DATA_ROOT
 

--- a/doc/source/commands/keg.rst
+++ b/doc/source/commands/keg.rst
@@ -70,4 +70,4 @@ EXAMPLE
 
    $ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
 
-   $ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2
+   $ keg --recipes-root keg-recipes --dest-dir leap_description leap/jeos/15.2

--- a/doc/source/commands/keg.rst
+++ b/doc/source/commands/keg.rst
@@ -1,28 +1,73 @@
 keg
 ===
 
+.. _keg_synopsis:
+
 SYNOPSIS
 --------
 
 .. code:: bash
 
+   keg (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
+       [-a ADD_DATA_ROOT] ... [-d DEST_DIR] [-fv]
+       SOURCE
+   keg -h | --help
    keg -h | --help
 
 DESCRIPTION
 -----------
 
-Description
+Keg is a tool which helps to create and manage image descriptions suitable
+for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder. Its
+main use case is to keep control over a larger amount of image descriptions
+and prevent duplication of description data.
+
+The key component for Keg is a data structure called `image definition tree`.
+This data structure contains all information to create KIWI image
+descriptions and provides data in a way that no or as little as possible
+duplication exists.
+
+Please find an implementation of an `image definition tree` with
+a focus on Public Cloud images here:
+`Public Cloud Image Definition Tree <https://github.com/SUSE-Enceladus/keg-recipes>`__
+
+.. _keg_options:
+
+ARGUMENTS
+---------
+
+SOURCE
+
+  Path to image source, expected under RECIPES_ROOT/images
 
 OPTIONS
 -------
 
---help
+-r RECIPES_ROOT, --recipes-root=RECIPES_ROOT
 
-  help
+  Root directory of keg recipes
+
+-a ADD_DATA_ROOT, --add-data-root=ADD_DATA_ROOT
+
+  Additional data root directory of recipes (multiples allowed)
+
+-d DEST_DIR, --dest-dir=DEST_DIR
+
+  Destination directory for generated description, default cwd
+
+-f, --force
+
+  Force mode (ignore errors, overwrite files)
+
+-v, --verbose
+
+  Enable verbose output
 
 EXAMPLE
 -------
 
 .. code:: bash
 
-   $ keg
+   $ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
+
+   $ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# KEG documentation build configuration file
+# Keg documentation build configuration file
 #
 import sys
 from os.path import abspath, dirname, join, normpath
@@ -40,7 +40,7 @@ master_doc = 'index'
 default_role="py:obj"
 
 # General information about the project.
-project = 'KEG - Image Composition Tool'
+project = 'Keg - Image Composition Tool'
 copyright = '2020, SUSE - Public Cloud Team'
 author = 'public-cloud-dev@suse.de'
 
@@ -73,7 +73,7 @@ todo_include_todos = True
 extlinks = {
     'issue': ('https://github.com/SUSE-Enceladus/keg/issues/%s', '#'),
     'pr': ('https://github.com/SUSE-Enceladus/keg/pull/%s', 'PR #'),
-    'ghkeg': ('https://github.com/SUSE-Enceladus/keg/blob/master/%s', '')
+    'ghkeg': ('https://github.com/SUSE-Enceladus/keg/blob/main/%s', '')
 }
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,15 @@
+.. keg documentation master file
+
+Keg Documentation
+=================
+
 .. toctree::
    :maxdepth: 1
 
+   overview
+   installation
    commands
+
+.. sidebar:: Links
+
+   * `GitHub Sources <https://github.com/SUSE-Enceladus/keg>`__

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -3,4 +3,19 @@
 Installation
 ============
 
-# TODO
+.. note::
+
+    This document describes how to install Keg. Currently keg is
+    provided from `PyPi <https://pypi.org/project/kiwi_keg/>`__ and
+    further install methods for Linux distributions will follow
+    soon.
+
+Installation from PyPI
+----------------------
+
+Keg can be obtained from the Python Package Index (PyPi) via Python's
+package manager pip:
+
+.. code:: shell-session
+
+   $ pip install kiwi_keg

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 .. note::
 
-    This document describes how to install Keg. Currently keg is
+    This document describes how to install Keg. Currently `keg` is
     provided from `PyPi <https://pypi.org/project/kiwi_keg/>`__ and
     further install methods for Linux distributions will follow
     soon.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -1,0 +1,6 @@
+.. _installation:
+
+Installation
+============
+
+# TODO

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -6,7 +6,7 @@ Overview
 .. note:: **Abstract**
 
    This document provides a conceptual overview about the steps of creating
-   an image description with keg which can be used to build an appliance
+   an image description with `keg` which can be used to build an appliance
    with the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder.
 
 Conceptual Overview
@@ -14,15 +14,15 @@ Conceptual Overview
 
 Keg is a tool which helps to create and manage image descriptions suitable
 for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder. 
-While keg can be used to manage a single image definition the tool provides
+While `keg` can be used to manage a single image definition the tool provides
 no considerable advantage in such a use case. The primary use case for keg
 are situations where many image descriptions must be managed and the
 image descriptions have considerable over lap with respect to content
 and setup.
 
-The key component for Keg is a data structure called `image definition tree`.
+The key component for `keg` is a data structure called `image definition tree`.
 This data structure is expected to contain all information necessary to
-create KIWI image descriptions. Keg is implemented such that data inheritance 
+create KIWI image descriptions. `keg` is implemented such that data inheritance 
 is possible to reduce data duplication in the `image definition tree`.
 
 The `image definition tree` consists of three major components:
@@ -52,7 +52,7 @@ can be found here:
 Working With Keg
 ----------------
 
-Using Keg is a two step process:
+Using `keg` is a two step process:
 
 1. Fetch or create an `image definition tree`
 
@@ -62,7 +62,7 @@ For the above to work, Keg needs to be installed as described in
 :ref:`installation`. In addition install KIWI:
 https://osinside.github.io/kiwi/installation.html
 
-If all software components are installed, Keg can be utilized like
+If all software components are installed, `keg` can be utilized like
 the following example shows:
 
 .. code:: shell-session
@@ -72,12 +72,12 @@ the following example shows:
     $ keg --recipes-root keg-recipes --dest-dir leap_description \
           leap/jeos/15.2
 
-After the keg command completes the destination directory specified
+After the `keg` command completes the destination directory specified
 with `--dest-dir` contains and image description that can be processed
 with kiwi to build an image. For more details about kiwi image descriptions
 see: https://osinside.github.io/kiwi/image_description.html
 
-With kiwi installed you can build the image with the keg created image
+With kiwi installed you can build the image with the `keg` created image
 description as follows:
 
 .. code:: shell-session

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -13,15 +13,19 @@ Conceptual Overview
 -------------------
 
 Keg is a tool which helps to create and manage image descriptions suitable
-for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder. Its
-main use case is to keep control over a larger amount of image descriptions
-and prevent duplication of description data.
+for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder. 
+While keg can be used to manage a single image definition the tool provides
+no considerable advantage in such a use case. The primary use case for keg
+are situations where many image descriptions must be managed and the
+image descriptions have considerable over lap with respect to content
+and setup.
 
 The key component for Keg is a data structure called `image definition tree`.
-This data structure contains all information to create KIWI image
-descriptions and provides data in a way that no or as little as possible
-duplication exists. The `image definition tree` consists out of three
-major components:
+This data structure is expected to contain all information necessary to
+create KIWI image descriptions. Keg is implemented such that data inheritance 
+is possible to reduce data duplication in the `image definition tree`.
+
+The `image definition tree` consists of three major components:
 
 Data Building Blocks: :file:`data`
   Independent collection of components used in KIWI image
@@ -41,30 +45,21 @@ Schema Templates: :file:`schemas`
   files as required by KIWI
 
 The setup of the `image definition tree` is the most time consuming
-part when using Keg. Because of this reason it's part of the Keg
-project to provide one implementation of such a tree as a service to
-our users. The provided information will be done with the scope set
-on **Public Clouds**. As we from the public cloud development team
-use Keg to manage our own image descriptions it's natural that the
-provided data in the open source project is aligned to cloud
-environments. However, this is not a limitation and we welcome any
-contributions independent of the target they serve. Please find
-our `image definition tree` here:
+part when using Keg. Example definitions for the `image definition tree`
+can be found here:
 `Public Cloud Image Definition Tree <https://github.com/SUSE-Enceladus/keg-recipes>`__
 
 Working With Keg
 ----------------
 
-Using Keg is done in three steps:
+Using Keg is a two step process:
 
 1. Fetch or create an `image definition tree`
 
 2. Call the `keg` commandline utility to create a KIWI image description
 
-3. Call `kiwi-ng` and create an appliance from the description
-
 For the above to work, Keg needs to be installed as described in
-:ref:`installation`. In addition install KIWI as described here:
+:ref:`installation`. In addition install KIWI:
 https://osinside.github.io/kiwi/installation.html
 
 If all software components are installed, Keg can be utilized like
@@ -76,6 +71,16 @@ the following example shows:
 
     $ keg --recipes-root keg-recipes --dest-dir leap_description \
           leap/jeos/15.2
+
+After the keg command completes the destination directory specified
+with `--dest-dir` contains and image description that can be processed
+with kiwi to build an image. For more details about kiwi image descriptions
+see: https://osinside.github.io/kiwi/image_description.html
+
+With kiwi installed you can build the image with the keg created image
+description as follows:
+
+.. code:: shell-session
 
     $ sudo kiwi-ng system build --description leap_description \
           --target-dir leap_image

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -1,0 +1,79 @@
+.. _overview:
+
+Overview
+========
+
+.. note:: **Abstract**
+
+   This document provides a conceptual overview about the steps of creating
+   an image description with keg which can be used to build an appliance
+   with the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder.
+
+Conceptual Overview
+-------------------
+
+Keg is a tool which helps to create and manage image descriptions suitable
+for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder. Its
+main use case is to keep control over a larger amount of image descriptions
+and prevent duplication of description data.
+
+The key component for Keg is a data structure called `image definition tree`.
+This data structure contains all information to create KIWI image
+descriptions and provides data in a way that no or as little as possible
+duplication exists. The `image definition tree` consists out of three
+major components:
+
+Data Building Blocks: :file:`data`
+  Independent collection of components used in KIWI image
+  descriptions. This includes for example information about
+  packages, repositories or custom script code and more.
+  A building block should be created to represent a certain
+  functionality or to provide a capability for a certain
+  target distribution such that it can be used in a variety
+  of different image descriptions. 
+
+Image Definitions: :file:`images`
+  Formal instructions which building blocks should be used for
+  the specified image
+
+Schema Templates: :file:`schemas`
+  Templates to implement Syntax and Semantic of image description
+  files as required by KIWI
+
+The setup of the `image definition tree` is the most time consuming
+part when using Keg. Because of this reason it's part of the Keg
+project to provide one implementation of such a tree as a service to
+our users. The provided information will be done with the scope set
+on **Public Clouds**. As we from the public cloud development team
+use Keg to manage our own image descriptions it's natural that the
+provided data in the open source project is aligned to cloud
+environments. However, this is not a limitation and we welcome any
+contributions independent of the target they serve. Please find
+our `image definition tree` here:
+`Public Cloud Image Definition Tree <https://github.com/SUSE-Enceladus/keg-recipes>`__
+
+Working With Keg
+----------------
+
+Using Keg is done in three steps:
+
+1. Fetch or create an `image definition tree`
+
+2. Call the `keg` commandline utility to create a KIWI image description
+
+3. Call `kiwi-ng` and create an appliance from the description
+
+For the above to work, Keg needs to be installed as described in
+:ref:`installation`. In addition install KIWI as described here:
+https://osinside.github.io/kiwi/installation.html
+
+If all software components are installed, Keg can be utilized like
+the following example shows:
+
+.. code::
+
+    $ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
+
+    $ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2
+
+    $ sudo kiwi-ng system build --description sles_description --target-dir kiwi_image

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -74,8 +74,8 @@ the following example shows:
 
     $ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
 
-    $ keg --recipes-root keg-recipes --dest-dir sles_description \
-          sles/byos/15-sp2
+    $ keg --recipes-root keg-recipes --dest-dir leap_description \
+          leap/jeos/15.2
 
-    $ sudo kiwi-ng system build --description sles_description \
-          --target-dir kiwi_image
+    $ sudo kiwi-ng system build --description leap_description \
+          --target-dir leap_image

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -70,10 +70,12 @@ https://osinside.github.io/kiwi/installation.html
 If all software components are installed, Keg can be utilized like
 the following example shows:
 
-.. code::
+.. code:: shell-session
 
     $ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
 
-    $ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2
+    $ keg --recipes-root keg-recipes --dest-dir sles_description \
+          sles/byos/15-sp2
 
-    $ sudo kiwi-ng system build --description sles_description --target-dir kiwi_image
+    $ sudo kiwi-ng system build --description sles_description \
+          --target-dir kiwi_image

--- a/doc/xml/book.xml
+++ b/doc/xml/book.xml
@@ -28,14 +28,17 @@
     <section xml:id="conceptual-overview">
       <title>Conceptual Overview</title>
       <para>Keg is a tool which helps to create and manage image descriptions suitable
-                for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder. Its
-                main use case is to keep control over a larger amount of image descriptions
-                and prevent duplication of description data.</para>
+                for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder.
+                While keg can be used to manage a single image definition the tool provides
+                no considerable advantage in such a use case. The primary use case for keg
+                are situations where many image descriptions must be managed and the
+                image descriptions have considerable over lap with respect to content
+                and setup.</para>
       <para>The key component for Keg is a data structure called <literal>image definition tree</literal>.
-                This data structure contains all information to create KIWI image
-                descriptions and provides data in a way that no or as little as possible
-                duplication exists. The <literal>image definition tree</literal> consists out of three
-                major components:</para>
+                This data structure is expected to contain all information necessary to
+                create KIWI image descriptions. Keg is implemented such that data inheritance
+                is possible to reduce data duplication in the <literal>image definition tree</literal>.</para>
+      <para>The <literal>image definition tree</literal> consists of three major components:</para>
       <variablelist>
         <varlistentry>
           <term>Data Building Blocks: <literal>data</literal></term>
@@ -65,20 +68,13 @@
         </varlistentry>
       </variablelist>
       <para>The setup of the <literal>image definition tree</literal> is the most time consuming
-                part when using Keg. Because of this reason it’s part of the Keg
-                project to provide one implementation of such a tree as a service to
-                our users. The provided information will be done with the scope set
-                on <emphasis role="bold">Public Clouds</emphasis>. As we from the public cloud development team
-                use Keg to manage our own image descriptions it’s natural that the
-                provided data in the open source project is aligned to cloud
-                environments. However, this is not a limitation and we welcome any
-                contributions independent of the target they serve. Please find
-                our <literal>image definition tree</literal> here:
+                part when using Keg. Example definitions for the <literal>image definition tree</literal>
+                can be found here:
                 <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://github.com/SUSE-Enceladus/keg-recipes">Public Cloud Image Definition Tree</link></para>
     </section>
     <section xml:id="working-with-keg">
       <title>Working With Keg</title>
-      <para>Using Keg is done in three steps:</para>
+      <para>Using Keg is a two step process:</para>
       <procedure>
         <step>
           <para>Fetch or create an <literal>image definition tree</literal></para>
@@ -86,22 +82,24 @@
         <step>
           <para>Call the <literal>keg</literal> commandline utility to create a KIWI image description</para>
         </step>
-        <step>
-          <para>Call <literal>kiwi-ng</literal> and create an appliance from the description</para>
-        </step>
       </procedure>
       <para>For the above to work, Keg needs to be installed as described in
-                <xref linkend="installation"/>. In addition install KIWI as described here:
+                <xref linkend="installation"/>. In addition install KIWI:
                 <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/installation.html"/></para>
       <para>If all software components are installed, Keg can be utilized like
                 the following example shows:</para>
       <screen language="shell-session">$ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
 
-$ keg --recipes-root keg-recipes --dest-dir sles_description \
-      sles/byos/15-sp2
-
-$ sudo kiwi-ng system build --description sles_description \
-      --target-dir kiwi_image</screen>
+$ keg --recipes-root keg-recipes --dest-dir leap_description \
+      leap/jeos/15.2</screen>
+      <para>After the keg command completes the destination directory specified
+                with <literal>--dest-dir</literal> contains and image description that can be processed
+                with kiwi to build an image. For more details about kiwi image descriptions
+                see: <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/image_description.html"/></para>
+      <para>With kiwi installed you can build the image with the keg created image
+                description as follows:</para>
+      <screen language="shell-session">$ sudo kiwi-ng system build --description leap_description \
+      --target-dir leap_image</screen>
     </section>
   </chapter>
   <chapter xml:id="installation" xml:base="installation">
@@ -134,13 +132,16 @@ keg -h | --help</screen>
       <section xml:id="description">
         <title>DESCRIPTION</title>
         <para>Keg is a tool which helps to create and manage image descriptions suitable
-                for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder. Its
-                main use case is to keep control over a larger amount of image descriptions
-                and prevent duplication of description data.</para>
+                for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder.
+                While keg can be used to manage a single image definition the tool provides
+                no considerable advantage in such a use case. The primary use case for keg
+                are situations where many image descriptions must be managed and the
+                image descriptions have considerable over lap with respect to content
+                and setup.</para>
         <para>The key component for Keg is a data structure called <literal>image definition tree</literal>.
-                This data structure contains all information to create KIWI image
-                descriptions and provides data in a way that no or as little as possible
-                duplication exists.</para>
+                This data structure is expected to contain all information necessary to
+                create KIWI image descriptions. Keg is implemented such that data inheritance
+                is possible to reduce data duplication in the <literal>image definition tree</literal>.</para>
         <para>Please find an implementation of an <literal>image definition tree</literal> with
                 a focus on Public Cloud images here:
                 <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://github.com/SUSE-Enceladus/keg-recipes">Public Cloud Image Definition Tree</link></para>
@@ -204,7 +205,7 @@ keg -h | --help</screen>
         <title>EXAMPLE</title>
         <screen language="bash">$ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
 
-$ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2</screen>
+$ keg --recipes-root keg-recipes --dest-dir leap_description leap/jeos/15.2</screen>
       </section>
     </section>
   </chapter>

--- a/doc/xml/book.xml
+++ b/doc/xml/book.xml
@@ -95,16 +95,29 @@
                 <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/installation.html"/></para>
       <para>If all software components are installed, Keg can be utilized like
                 the following example shows:</para>
-      <screen language="default">$ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
+      <screen language="shell-session">$ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
 
-$ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2
+$ keg --recipes-root keg-recipes --dest-dir sles_description \
+      sles/byos/15-sp2
 
-$ sudo kiwi-ng system build --description sles_description --target-dir kiwi_image</screen>
+$ sudo kiwi-ng system build --description sles_description \
+      --target-dir kiwi_image</screen>
     </section>
   </chapter>
   <chapter xml:id="installation" xml:base="installation">
     <title>Installation</title>
-    <para># TODO</para>
+    <note>
+      <para>This document describes how to install Keg. Currently keg is
+                provided from <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://pypi.org/project/kiwi_keg/">PyPi</link> and
+                further install methods for Linux distributions will follow
+                soon.</para>
+    </note>
+    <section xml:id="installation-from-pypi">
+      <title>Installation from PyPI</title>
+      <para>Keg can be obtained from the Python Package Index (PyPi) via Python’s
+                package manager pip:</para>
+      <screen language="shell-session">$ pip install kiwi_keg</screen>
+    </section>
   </chapter>
   <chapter xml:id="command-line" xml:base="commands">
     <title>Command Line</title>

--- a/doc/xml/book.xml
+++ b/doc/xml/book.xml
@@ -1,0 +1,198 @@
+<?xml-model 
+      href="file:/usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
+      type="application/relax-ng-compact-syntax"
+     ?>
+<book xmlns="http://docbook.org/ns/docbook" xml:lang="en" version="5.1" xml:id="keg-documentation">
+  <title>Keg Documentation</title>
+  <info/>
+  <preface>
+    <title>Preface</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://github.com/SUSE-Enceladus/keg">GitHub Sources</link>
+        </para>
+      </listitem>
+    </itemizedlist>
+  </preface>
+  <chapter xml:id="overview" xml:base="overview">
+    <title>Overview</title>
+    <note>
+      <para>
+        <emphasis role="bold">Abstract</emphasis>
+      </para>
+      <para>This document provides a conceptual overview about the steps of creating
+                an image description with keg which can be used to build an appliance
+                with the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder.</para>
+    </note>
+    <section xml:id="conceptual-overview">
+      <title>Conceptual Overview</title>
+      <para>Keg is a tool which helps to create and manage image descriptions suitable
+                for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder. Its
+                main use case is to keep control over a larger amount of image descriptions
+                and prevent duplication of description data.</para>
+      <para>The key component for Keg is a data structure called <literal>image definition tree</literal>.
+                This data structure contains all information to create KIWI image
+                descriptions and provides data in a way that no or as little as possible
+                duplication exists. The <literal>image definition tree</literal> consists out of three
+                major components:</para>
+      <variablelist>
+        <varlistentry>
+          <term>Data Building Blocks: <literal>data</literal></term>
+          <listitem>
+            <para>Independent collection of components used in KIWI image
+                            descriptions. This includes for example information about
+                            packages, repositories or custom script code and more.
+                            A building block should be created to represent a certain
+                            functionality or to provide a capability for a certain
+                            target distribution such that it can be used in a variety
+                            of different image descriptions.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Image Definitions: <literal>images</literal></term>
+          <listitem>
+            <para>Formal instructions which building blocks should be used for
+                            the specified image</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Schema Templates: <literal>schemas</literal></term>
+          <listitem>
+            <para>Templates to implement Syntax and Semantic of image description
+                            files as required by KIWI</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <para>The setup of the <literal>image definition tree</literal> is the most time consuming
+                part when using Keg. Because of this reason it’s part of the Keg
+                project to provide one implementation of such a tree as a service to
+                our users. The provided information will be done with the scope set
+                on <emphasis role="bold">Public Clouds</emphasis>. As we from the public cloud development team
+                use Keg to manage our own image descriptions it’s natural that the
+                provided data in the open source project is aligned to cloud
+                environments. However, this is not a limitation and we welcome any
+                contributions independent of the target they serve. Please find
+                our <literal>image definition tree</literal> here:
+                <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://github.com/SUSE-Enceladus/keg-recipes">Public Cloud Image Definition Tree</link></para>
+    </section>
+    <section xml:id="working-with-keg">
+      <title>Working With Keg</title>
+      <para>Using Keg is done in three steps:</para>
+      <procedure>
+        <step>
+          <para>Fetch or create an <literal>image definition tree</literal></para>
+        </step>
+        <step>
+          <para>Call the <literal>keg</literal> commandline utility to create a KIWI image description</para>
+        </step>
+        <step>
+          <para>Call <literal>kiwi-ng</literal> and create an appliance from the description</para>
+        </step>
+      </procedure>
+      <para>For the above to work, Keg needs to be installed as described in
+                <xref linkend="installation"/>. In addition install KIWI as described here:
+                <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/installation.html"/></para>
+      <para>If all software components are installed, Keg can be utilized like
+                the following example shows:</para>
+      <screen language="default">$ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
+
+$ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2
+
+$ sudo kiwi-ng system build --description sles_description --target-dir kiwi_image</screen>
+    </section>
+  </chapter>
+  <chapter xml:id="installation" xml:base="installation">
+    <title>Installation</title>
+    <para># TODO</para>
+  </chapter>
+  <chapter xml:id="command-line" xml:base="commands">
+    <title>Command Line</title>
+    <section xml:id="keg" xml:base="commands/keg">
+      <title>keg</title>
+      <section xml:id="keg-synopsis">
+        <title>SYNOPSIS</title>
+        <screen language="bash">keg (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
+    [-a ADD_DATA_ROOT] ... [-d DEST_DIR] [-fv]
+    SOURCE
+keg -h | --help
+keg -h | --help</screen>
+      </section>
+      <section xml:id="description">
+        <title>DESCRIPTION</title>
+        <para>Keg is a tool which helps to create and manage image descriptions suitable
+                for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder. Its
+                main use case is to keep control over a larger amount of image descriptions
+                and prevent duplication of description data.</para>
+        <para>The key component for Keg is a data structure called <literal>image definition tree</literal>.
+                This data structure contains all information to create KIWI image
+                descriptions and provides data in a way that no or as little as possible
+                duplication exists.</para>
+        <para>Please find an implementation of an <literal>image definition tree</literal> with
+                a focus on Public Cloud images here:
+                <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://github.com/SUSE-Enceladus/keg-recipes">Public Cloud Image Definition Tree</link></para>
+      </section>
+      <section xml:id="keg-options">
+        <title>ARGUMENTS</title>
+        <para>SOURCE</para>
+        <para>Path to image source, expected under RECIPES_ROOT/images</para>
+      </section>
+      <section xml:id="options">
+        <title>OPTIONS</title>
+        <variablelist>
+          <varlistentry>
+            <term>
+              <option>-r</option>
+              <option>--recipes-root</option>
+            </term>
+            <listitem>
+              <para>Root directory of keg recipes</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <option>-a</option>
+              <option>--add-data-root</option>
+            </term>
+            <listitem>
+              <para>Additional data root directory of recipes (multiples allowed)</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <option>-d</option>
+              <option>--dest-dir</option>
+            </term>
+            <listitem>
+              <para>Destination directory for generated description, default cwd</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <option>-f</option>
+              <option>--force</option>
+            </term>
+            <listitem>
+              <para>Force mode (ignore errors, overwrite files)</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <option>-v</option>
+              <option>--verbose</option>
+            </term>
+            <listitem>
+              <para>Enable verbose output</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+      <section xml:id="example">
+        <title>EXAMPLE</title>
+        <screen language="bash">$ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
+
+$ keg --recipes-root keg-recipes --dest-dir sles_description sles/byos/15-sp2</screen>
+      </section>
+    </section>
+  </chapter>
+</book>

--- a/doc/xml/book.xml
+++ b/doc/xml/book.xml
@@ -22,21 +22,21 @@
         <emphasis role="bold">Abstract</emphasis>
       </para>
       <para>This document provides a conceptual overview about the steps of creating
-                an image description with keg which can be used to build an appliance
+                an image description with <literal>keg</literal> which can be used to build an appliance
                 with the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder.</para>
     </note>
     <section xml:id="conceptual-overview">
       <title>Conceptual Overview</title>
       <para>Keg is a tool which helps to create and manage image descriptions suitable
                 for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder.
-                While keg can be used to manage a single image definition the tool provides
+                While <literal>keg</literal> can be used to manage a single image definition the tool provides
                 no considerable advantage in such a use case. The primary use case for keg
                 are situations where many image descriptions must be managed and the
                 image descriptions have considerable over lap with respect to content
                 and setup.</para>
-      <para>The key component for Keg is a data structure called <literal>image definition tree</literal>.
+      <para>The key component for <literal>keg</literal> is a data structure called <literal>image definition tree</literal>.
                 This data structure is expected to contain all information necessary to
-                create KIWI image descriptions. Keg is implemented such that data inheritance
+                create KIWI image descriptions. <literal>keg</literal> is implemented such that data inheritance
                 is possible to reduce data duplication in the <literal>image definition tree</literal>.</para>
       <para>The <literal>image definition tree</literal> consists of three major components:</para>
       <variablelist>
@@ -74,7 +74,7 @@
     </section>
     <section xml:id="working-with-keg">
       <title>Working With Keg</title>
-      <para>Using Keg is a two step process:</para>
+      <para>Using <literal>keg</literal> is a two step process:</para>
       <procedure>
         <step>
           <para>Fetch or create an <literal>image definition tree</literal></para>
@@ -86,17 +86,17 @@
       <para>For the above to work, Keg needs to be installed as described in
                 <xref linkend="installation"/>. In addition install KIWI:
                 <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/installation.html"/></para>
-      <para>If all software components are installed, Keg can be utilized like
+      <para>If all software components are installed, <literal>keg</literal> can be utilized like
                 the following example shows:</para>
       <screen language="shell-session">$ git clone https://github.com/SUSE-Enceladus/keg-recipes.git
 
 $ keg --recipes-root keg-recipes --dest-dir leap_description \
       leap/jeos/15.2</screen>
-      <para>After the keg command completes the destination directory specified
+      <para>After the <literal>keg</literal> command completes the destination directory specified
                 with <literal>--dest-dir</literal> contains and image description that can be processed
                 with kiwi to build an image. For more details about kiwi image descriptions
                 see: <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/image_description.html"/></para>
-      <para>With kiwi installed you can build the image with the keg created image
+      <para>With kiwi installed you can build the image with the <literal>keg</literal> created image
                 description as follows:</para>
       <screen language="shell-session">$ sudo kiwi-ng system build --description leap_description \
       --target-dir leap_image</screen>
@@ -105,7 +105,7 @@ $ keg --recipes-root keg-recipes --dest-dir leap_description \
   <chapter xml:id="installation" xml:base="installation">
     <title>Installation</title>
     <note>
-      <para>This document describes how to install Keg. Currently keg is
+      <para>This document describes how to install Keg. Currently <literal>keg</literal> is
                 provided from <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://pypi.org/project/kiwi_keg/">PyPi</link> and
                 further install methods for Linux distributions will follow
                 soon.</para>
@@ -133,7 +133,7 @@ keg -h | --help</screen>
         <title>DESCRIPTION</title>
         <para>Keg is a tool which helps to create and manage image descriptions suitable
                 for the <link xmlns:xl="http://www.w3.org/1999/xlink" xl:href="https://osinside.github.io/kiwi/">KIWI</link> appliance builder.
-                While keg can be used to manage a single image definition the tool provides
+                While <literal>keg</literal> can be used to manage a single image definition the tool provides
                 no considerable advantage in such a use case. The primary use case for keg
                 are situations where many image descriptions must be managed and the
                 image descriptions have considerable over lap with respect to content
@@ -160,7 +160,7 @@ keg -h | --help</screen>
               <option>--recipes-root</option>
             </term>
             <listitem>
-              <para>Root directory of keg recipes</para>
+              <para>Root directory of Keg recipes</para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,12 @@ envlist =
 [testenv]
 whitelist_externals = *
 basepython =
-    {check,devel,doc}: python3
+    {check,devel,doc,doc_suse}: python3
     unit_py3_8: python3.8
     unit_py3_6: python3.6
     release: python3.6
 envdir =
-    {check,devel,doc}: {toxworkdir}/3
+    {check,devel,doc,doc_suse}: {toxworkdir}/3
     unit_py3_8: {toxworkdir}/3.8
     unit_py3_6: {toxworkdir}/3.6
     release: {toxworkdir}/3.6
@@ -91,6 +91,19 @@ commands =
     {[testenv:doc.html]commands}
     {[testenv:doc.man]commands}
 
+[testenv:doc_suse]
+description = Documentation build suitable for SUSE documentation
+skip_install = True
+usedevelop = True
+deps = {[testenv:doc]deps}
+changedir=doc
+commands =
+    {[testenv:doc.xml]commands}
+    rstxml2docbook -v --no-split -o xml/book.xml build/restxml/index.xml
+    cp -a xml build/
+    cp DC-keg build/
+    bash -c 'cd build && daps -d DC-keg html'
+
 [testenv:doc.html]
 description = Documentation build html result
 skip_install = True
@@ -98,6 +111,16 @@ deps = {[testenv:doc]deps}
 changedir=doc
 commands =
     make html
+
+[testenv:doc.xml]
+description = Documentation build xml result
+skip_install = True
+deps = {[testenv:doc]deps}
+changedir=doc
+commands =
+    make xml
+    rm -rf build/restxml
+    mv build/xml build/restxml
 
 # Documentation build man pages
 [testenv:doc.man]

--- a/tox.ini
+++ b/tox.ini
@@ -88,8 +88,16 @@ usedevelop = True
 deps = {[testenv]deps}
 changedir=doc
 commands =
+    {[testenv:doc.html]commands}
     {[testenv:doc.man]commands}
 
+[testenv:doc.html]
+description = Documentation build html result
+skip_install = True
+deps = {[testenv:doc]deps}
+changedir=doc
+commands =
+    make html
 
 # Documentation build man pages
 [testenv:doc.man]


### PR DESCRIPTION
This change is two fold

**Added Keg Documentation**
    
Added overview chapter and update manual page as well as say some words how to install
keg. This Fixes #7

**Added doc_suse tox target**
    
Build SUSE documentation from sphinx based project. This will be the docs that gets published on
documentation.suse.com. The suse target is auto generated from the ReST sources. The doc team
can easily manage the data you find in doc/xml at the time we point them to this github repo
