### PR TITLE
Preserve XML comments

### DIFF
--- a/doc/source/commands/keg.rst
+++ b/doc/source/commands/keg.rst
@@ -9,6 +9,7 @@ SYNOPSIS
 .. code:: bash
 
    keg (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
+       [--format-xml|--format-yaml]
        [-a ADD_DATA_ROOT] ... [-d DEST_DIR] [-fv]
        SOURCE
    keg -h | --help
@@ -61,6 +62,29 @@ OPTIONS
 -f, --force
 
   Force mode (ignore errors, overwrite files)
+
+--format-yaml
+
+  Format/Update Keg written image description to installed
+  KIWI schema and write the result description in YAML markup.
+
+  .. note::
+
+     Currently no translation of comment blocks from the Keg
+     generated KIWI description to the YAML markup will be
+     performed
+
+--format-xml
+
+  Format/Update Keg written image description to installed
+  KIWI schema and write the result description in XML markup
+
+  .. note::
+
+     Currently only toplevel header comments from the Keg
+     written image description will be preserved into the
+     formatted/updated KIWI XML file. Inline comments will
+     not be preserved.
 
 -v, --verbose
 

--- a/doc/xml/book.xml
+++ b/doc/xml/book.xml
@@ -124,6 +124,7 @@ $ keg --recipes-root keg-recipes --dest-dir leap_description \
       <section xml:id="keg-synopsis">
         <title>SYNOPSIS</title>
         <screen language="bash">keg (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
+    [--format-xml|--format-yaml]
     [-a ADD_DATA_ROOT] ... [-d DEST_DIR] [-fv]
     SOURCE
 keg -h | --help
@@ -188,6 +189,35 @@ keg -h | --help</screen>
             </term>
             <listitem>
               <para>Force mode (ignore errors, overwrite files)</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <option>--format-yaml</option>
+            </term>
+            <listitem>
+              <para>Format/Update Keg written image description to installed
+                            KIWI schema and write the result description in YAML markup.</para>
+              <note>
+                <para>Currently no translation of comment blocks from the Keg
+                                generated KIWI description to the YAML markup will be
+                                performed</para>
+              </note>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <option>--format-xml</option>
+            </term>
+            <listitem>
+              <para>Format/Update Keg written image description to installed
+                            KIWI schema and write the result description in XML markup</para>
+              <note>
+                <para>Currently only toplevel header comments from the Keg
+                                written image description will be preserved into the
+                                formatted/updated KIWI XML file. Inline comments will
+                                not be preserved.</para>
+              </note>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/kiwi_keg/generator.py
+++ b/kiwi_keg/generator.py
@@ -46,6 +46,12 @@ class KegGenerator:
                     target=repr(dest_dir)
                 )
             )
+        self.kiwi_description = os.path.join(
+            dest_dir, 'config.kiwi'
+        )
+        self.kiwi_config_script = os.path.join(
+            dest_dir, 'config.sh'
+        )
         self.image_definition = image_definition
         self.description_schemas = os.path.join(
             image_definition.recipes_root, 'schemas'
@@ -69,17 +75,14 @@ class KegGenerator:
             )
         )
 
-    def create_kiwi_description(
-        self, markup: str = 'xml', override: bool = False
-    ):
+    def create_kiwi_description(self, override: bool = False) -> None:
         """
         Creates KIWI config.xml from a KegImageDefinition.
 
         :param bool override:
             Override destination contents, default is: False
         """
-        outfile = os.path.join(self.dest_dir, 'config.kiwi')
-        self._validate_outfile(outfile, override)
+        self._check_file(self.kiwi_description, override)
 
         kiwi_template = self._read_template(
             '{}.kiwi.templ'.format(self.image_schema)
@@ -87,17 +90,30 @@ class KegGenerator:
         kiwi_document = kiwi_template.render(
             data=self.image_definition.data
         )
-        with open(outfile, 'w') as kiwi_config:
+        with open(self.kiwi_description, 'w') as kiwi_config:
             kiwi_config.write(kiwi_document)
-        kiwi = KiwiDescription(outfile)
-        if markup == 'xml':
-            kiwi.create_XML_description(outfile)
-        elif markup == 'yaml':
-            kiwi.create_YAML_description(outfile)
-        else:
+
+    def validate_kiwi_description(self) -> None:
+        kiwi = KiwiDescription(self.kiwi_description)
+        kiwi.validate_description()
+
+    def format_kiwi_description(self, markup: str = 'xml') -> None:
+        supported_markup_languages = ['xml', 'yaml']
+        kiwi = KiwiDescription(self.kiwi_description)
+        if markup not in supported_markup_languages:
             raise KegError(
                 'Unsupported markup type: {name}'.format(name=markup)
             )
+        log.info(
+            'Formatting Keg KIWI description to installed KIWI schema'
+        )
+        log.info(
+            f'--> Writing description in {markup!r} markup'
+        )
+        if markup == 'xml':
+            kiwi.create_XML_description(self.kiwi_description)
+        if markup == 'yaml':
+            kiwi.create_YAML_description(self.kiwi_description)
 
     def create_custom_scripts(self, override: bool = False):
         """
@@ -106,8 +122,7 @@ class KegGenerator:
         :param bool override:
             Override destination contents, default is: False
         """
-        outfile = os.path.join(self.dest_dir, 'config.sh')
-        self._validate_outfile(outfile, override)
+        self._check_file(self.kiwi_config_script, override)
         script_lib = KegUtils.load_scripts(
             self.image_definition.data_roots, 'scripts',
             self.image_definition.data.get('include-paths')
@@ -118,15 +133,15 @@ class KegGenerator:
         config_sh = config_template.render(
             data=self.image_definition.data, scripts=script_lib
         )
-        with open(outfile, 'w') as custom_script:
+        with open(self.kiwi_config_script, 'w') as custom_script:
             custom_script.write(config_sh)
 
     @staticmethod
-    def _validate_outfile(outfile, override):
-        if not override and os.path.exists(outfile):
+    def _check_file(filename, override):
+        if not override and os.path.exists(filename):
             raise KegError(
                 '{target} exists, use force to overwrite.'.format(
-                    target=outfile
+                    target=filename
                 )
             )
 

--- a/kiwi_keg/keg.py
+++ b/kiwi_keg/keg.py
@@ -17,6 +17,7 @@
 #
 """
 Usage: keg (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
+           [--format-xml|--format-yaml]
            [-a ADD_DATA_ROOT] ... [-d DEST_DIR] [-fv]
            SOURCE
        keg -h | --help
@@ -37,6 +38,14 @@ Options:
 
     -f, --force
        Force mode (ignore errors, overwrite files)
+
+    --format-yaml
+       Format/Update Keg written image description to installed
+       KIWI schema and write the result description in YAML markup
+
+    --format-xml
+       Format/Update Keg written image description to installed
+       KIWI schema and write the result description in XML markup
 
     -v, --verbose
         Enable verbose output
@@ -74,8 +83,14 @@ def main():
             dest_dir=args['--dest-dir']
         )
         image_generator.create_kiwi_description(
-            markup='xml', override=args['--force']
+            override=args['--force']
         )
+        if args['--format-yaml']:
+            image_generator.format_kiwi_description('yaml')
+        elif args['--format-xml']:
+            image_generator.format_kiwi_description('xml')
+        else:
+            image_generator.validate_kiwi_description()
         image_generator.create_custom_scripts(
             override=args['--force']
         )

--- a/test/data/keg_output_invalid/config_invalid.xml
+++ b/test/data/keg_output_invalid/config_invalid.xml
@@ -14,7 +14,7 @@
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>UTC</timezone>
-        <type image="oem" filesystem="btrfs" firmware="efi">
+        <type image="oem" filesystem="btrfs" firmware="efi" invalid_attr="uups">
             <oemconfig>
                 <oem-multipath-scan>false</oem-multipath-scan>
                 <oem-swap>true</oem-swap>

--- a/test/data/keg_output_xml/config.kiwi
+++ b/test/data/keg_output_xml/config.kiwi
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+some comment
+-->
+
+<!-- some other comment -->
+
+<!--
+Some long text
+and more text-->
+
+<image schemaversion="7.3" name="KEG">
+    <description type="system">
+        <author>Public Cloud Team</author>
+        <contact>pubcloud-dev@suse.com</contact>
+        <specification>
+            KEG written image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.2.3</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>UTC</timezone>
+        <type image="oem" filesystem="btrfs" firmware="efi">
+            <oemconfig>
+                <oem-multipath-scan>false</oem-multipath-scan>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+        </type>
+    </preferences>
+    <repository>
+        <source path="obs://path/to/project"/>
+    </repository>
+    <packages type="image">
+        <!-- some inline comment -->
+        <package name="joe"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/data/keg_output_xml/config.xml
+++ b/test/data/keg_output_xml/config.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-
+<!--
+some comment
+-->
+<!-- some other comment -->
+<!--
+Some long text
+and more text-->
 <image schemaversion="7.3" name="KEG">
     <description type="system">
         <author>Public Cloud Team</author>
         <contact>pubcloud-dev@suse.com</contact>
-        <specification>
-            KEG written image
-        </specification>
+        <specification>KEG written image</specification>
     </description>
     <preferences>
         <version>1.2.3</version>
@@ -14,7 +18,7 @@
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>UTC</timezone>
-        <type image="oem" filesystem="btrfs" firmware="efi" unknown="uups">
+        <type image="oem" filesystem="btrfs" firmware="efi">
             <oemconfig>
                 <oem-multipath-scan>false</oem-multipath-scan>
                 <oem-swap>true</oem-swap>

--- a/test/data/keg_output_yaml/config.kiwi
+++ b/test/data/keg_output_yaml/config.kiwi
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="7.3" name="KEG">
+    <description type="system">
+        <author>Public Cloud Team</author>
+        <contact>pubcloud-dev@suse.com</contact>
+        <specification>KEG written image</specification>
+    </description>
+    <preferences>
+        <version>1.2.3</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>UTC</timezone>
+        <type image="oem" filesystem="btrfs" firmware="efi">
+            <oemconfig>
+                <oem-multipath-scan>false</oem-multipath-scan>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+        </type>
+    </preferences>
+    <repository>
+        <source path="obs://path/to/project"/>
+    </repository>
+    <packages type="image">
+        <package name="joe"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/data/keg_output_yaml/config.yaml
+++ b/test/data/keg_output_yaml/config.yaml
@@ -1,0 +1,33 @@
+image:
+  '@name': KEG
+  '@schemaversion': '7.3'
+  description:
+    '@type': system
+    author: Public Cloud Team
+    contact: pubcloud-dev@suse.com
+    specification: KEG written image
+  packages:
+  - '@type': image
+    package:
+      '@name': joe
+  - '@type': bootstrap
+    package:
+    - '@name': udev
+    - '@name': filesystem
+    - '@name': glibc-locale
+  preferences:
+    keytable: us.map.gz
+    locale: en_US
+    packagemanager: zypper
+    timezone: UTC
+    type:
+      '@filesystem': btrfs
+      '@firmware': efi
+      '@image': oem
+      oemconfig:
+        oem-multipath-scan: 'false'
+        oem-swap: 'true'
+    version: 1.2.3
+  repository:
+    source:
+      '@path': obs://path/to/project

--- a/test/unit/keg_test.py
+++ b/test/unit/keg_test.py
@@ -41,10 +41,39 @@ class TestKeg:
                 image_definition=image_definition, dest_dir='some-target'
             )
             image_generator.create_kiwi_description.assert_called_once_with(
-                markup='xml', override=False
+                override=False
             )
+            image_generator.validate_kiwi_description.assert_called_once_with()
             image_generator.create_custom_scripts.assert_called_once_with(
                 override=False
+            )
+
+    @patch('kiwi_keg.keg.KegImageDefinition')
+    @patch('kiwi_keg.keg.KegGenerator')
+    def test_keg_format_xml(self, mock_KegGenerator, mock_KegImageDefinition):
+        sys.argv += ['--format-xml']
+        image_definition = Mock()
+        mock_KegImageDefinition.return_value = image_definition
+        image_generator = Mock()
+        mock_KegGenerator.return_value = image_generator
+        with self._caplog.at_level(logging.DEBUG):
+            main()
+            image_generator.format_kiwi_description.assert_called_once_with(
+                'xml'
+            )
+
+    @patch('kiwi_keg.keg.KegImageDefinition')
+    @patch('kiwi_keg.keg.KegGenerator')
+    def test_keg_format_yaml(self, mock_KegGenerator, mock_KegImageDefinition):
+        sys.argv += ['--format-yaml']
+        image_definition = Mock()
+        mock_KegImageDefinition.return_value = image_definition
+        image_generator = Mock()
+        mock_KegGenerator.return_value = image_generator
+        with self._caplog.at_level(logging.DEBUG):
+            main()
+            image_generator.format_kiwi_description.assert_called_once_with(
+                'yaml'
             )
 
     @patch('kiwi_keg.keg.KegImageDefinition')


### PR DESCRIPTION
The KIWI validation does not preserve comments after validation
as they have no meaning for the processing of the image description.
However for OBS comments are treated as project configurations
and therefore the toplevel comments if present must be added back.
This Fixes #19