### PR TITLE
Properly support overwriting of keys

### DIFF
--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -94,7 +94,7 @@ class KegImageDefinition:
         try:
             self._data.update(
                 KegUtils.get_recipes(
-                    [self.image_root], self.image_name
+                    [self.image_root], [self.image_name]
                 )
             )
         except Exception as issue:
@@ -127,32 +127,24 @@ class KegImageDefinition:
                 profile: Dict = {}
                 for item, value in profile_data.items():
                     if item == 'include':
-                        for inc in value:
-                            KegUtils.rmerge(
-                                KegUtils.get_recipes(
-                                    self.data_roots,
-                                    inc,
-                                    include_paths
-                                ),
-                                profile
-                            )
+                        KegUtils.rmerge(
+                            KegUtils.get_recipes(
+                                self.data_roots,
+                                value,
+                                include_paths
+                            ),
+                            profile
+                        )
                     else:
                         KegUtils.rmerge({item: value}, profile_data)
                 self._data['profiles'][profile_name].update(profile)
 
     def _update_contents(self, include_paths):
         if 'contents' in self._data:
-            contents: Dict = {}
-            for inc in self._data['contents'].get('include'):
-                KegUtils.rmerge(
-                    KegUtils.get_recipes(
-                        self.data_roots,
-                        inc,
-                        include_paths
-                    ),
-                    contents
-                )
-            self._data['contents'].update(contents)
+            includes = self._data['contents'].get('include')
+            self._data['contents'].update(
+                KegUtils.get_recipes(self._data_roots, includes, include_paths)
+            )
 
     def _generate_overlay_info(self):
         if 'contents' in self._data:

--- a/kiwi_keg/utils.py
+++ b/kiwi_keg/utils.py
@@ -60,7 +60,7 @@ class KegUtils:
 
     @staticmethod
     def get_recipes(
-        roots: List[str], sub_dir: str, include_paths: List[str] = None
+        roots: List[str], sub_dirs: List[str], include_paths: List[str] = None
     ) -> Dict[str, str]:
         """
         Return a new yaml tree including the data of all the source files for
@@ -70,15 +70,20 @@ class KegUtils:
         :param: str sub_dir: subdirectory path to get the files from
         :param: list include_paths: list of paths to be included
         """
-        desc_files = KegUtils._get_source_files(
-            roots, sub_dir, 'yaml', include_paths
-        )
+        desc_files = []
+        for sub_dir in sub_dirs:
+            desc_files += KegUtils._get_source_files(
+                roots, sub_dir, 'yaml', include_paths
+            )
         merged_tree: Dict[str, str] = {}
+        files_read = []
         for desc_file in desc_files:
-            log.debug(f'Reading: {desc_file}')
-            with open(desc_file, 'r') as f:
-                desc_yaml = yaml.safe_load(f.read())
-            KegUtils.rmerge(desc_yaml, merged_tree)
+            if desc_file not in files_read:
+                log.debug(f'Reading: {desc_file}')
+                with open(desc_file, 'r') as f:
+                    desc_yaml = yaml.safe_load(f.read())
+                KegUtils.rmerge(desc_yaml, merged_tree)
+                files_read.append(desc_file)
         return merged_tree
 
     @staticmethod
@@ -132,7 +137,7 @@ class KegUtils:
     def _get_source_files(roots, sub_dir, ext, include_paths):
         src_files = []
         for root_dir in roots:
-            src_files = KegUtils._get_versioned_source_files(
+            src_files += KegUtils._get_versioned_source_files(
                 os.path.join(root_dir, sub_dir),
                 ext,
                 include_paths

--- a/test/unit/utils_test.py
+++ b/test/unit/utils_test.py
@@ -26,7 +26,7 @@ class TestUtils:
             }
         }
         assert KegUtils.get_recipes(
-            ['../data/images'], 'leap_single_build', ['base/jeos/leap']
+            ['../data/images'], ['leap_single_build'], ['base/jeos/leap']
         ) == expected_output
 
     def test_load_scripts(self):


### PR DESCRIPTION
Keys from upper levels may be overwritten in lower levels, but adding subsequent data modules may revert that by merging upper level dict files again. This commit prevents duplicate merging.