### PR TITLE
Improve list-recipes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,8 @@
 [bumpversion]
-current_version = 0.0.8
+current_version = 1.0.0
 commit = True
 tag = True
 
 [bumpversion:file:kiwi_keg/version.py]
 
 [bumpversion:file:doc/source/conf.py]
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,7 +49,7 @@ author = 'public-cloud-dev@suse.de'
 # built documents.
 #
 # The short X.Y version.
-version = '0.0.8'
+version = '1.0.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/kiwi_keg/file_utils.py
+++ b/kiwi_keg/file_utils.py
@@ -112,20 +112,15 @@ def load_scripts(
     return script_lib
 
 
-def get_all_files(base_dir: str) -> Generator[str, None, None]:
+def get_all_leaf_dirs(base_dir: str) -> List[str]:
     """
-    Return a generator containing all the files paths in the sub directories
-    of a given path.
-    :param: str base_dir: directory path to get all the files from.
-    :return: generator with all the file paths inside that directory.
-
-    :rtype: generator
+    Return a list of leaf directories of a given path.
+    :param: str base_dir: directory path to scan
+    :return: list of all leaf directories
     """
-    for sub_dir in os.scandir(base_dir):
-        if sub_dir.is_dir():
-            yield from get_all_files(sub_dir.path)
-        elif sub_dir.is_file():
-            yield sub_dir.path
+    strip_offset = len(base_dir) + 1
+    walker = os.walk(base_dir)
+    return [x[0][strip_offset:] for x in walker if not x[1]]
 
 
 def _get_source_files(roots, sub_dir, ext, include_paths):

--- a/kiwi_keg/file_utils.py
+++ b/kiwi_keg/file_utils.py
@@ -19,7 +19,7 @@ import logging
 from glob import glob
 from pathlib import Path
 from typing import (
-    List, Dict, Generator
+    List, Dict
 )
 import os
 import yaml

--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -121,18 +121,6 @@ class KegImageDefinition:
         self._generate_config_scripts()
         self._generate_overlay_info()
 
-    def list_recipes(self):
-        images_recipes = []
-        for image_file in file_utils.get_all_files(self.image_root):
-            if os.path.basename(image_file) == 'image.yaml':
-                rel_path = os.path.relpath(
-                    os.path.dirname(image_file),
-                    self.image_root
-                )
-                images_recipes.append(rel_path)
-
-        return sorted(images_recipes)
-
     def _update_profiles(self, include_paths):
         if 'profiles' in self._data:
             for profile_name, profile_data in self._data['profiles'].items():

--- a/kiwi_keg/version.py
+++ b/kiwi_keg/version.py
@@ -18,5 +18,5 @@
 """
 Global version information used in keg and the package
 """
-__version__ = '0.0.8'
+__version__ = '1.0.0'
 __githash__ = '$Format:%H$'

--- a/test/unit/file_utils_test.py
+++ b/test/unit/file_utils_test.py
@@ -1,3 +1,4 @@
+from mock import patch
 from kiwi_keg import file_utils
 
 
@@ -36,3 +37,8 @@ class TestUtils:
         assert file_utils.load_scripts(
             ['../data/data'], 'scripts', ['base/jeos/leap']
         ) == expected_output
+
+    @patch('file_utils.os.walk')
+    def get_all_leaf_dirs(self, mock_os_walk):
+        mock_os_walk.return_value = ['foo', [], []]
+        assert file_utils.get_all_leaf_dirs('foo') == ['foo']

--- a/test/unit/image_definition_test.py
+++ b/test/unit/image_definition_test.py
@@ -110,13 +110,3 @@ class TestKegImageDefinition:
                          'home': '/root',
                          'name': 'root',
                          'password': 'foo'}]}
-
-    def test_list_recipes(self):
-        assert self.keg_definition.list_recipes() == [
-            'leap/15',
-            'leap/15.1',
-            'leap/15.2',
-            'leap_broken_overlay',
-            'leap_no_overlays',
-            'leap_single_build'
-        ]

--- a/test/unit/keg_test.py
+++ b/test/unit/keg_test.py
@@ -10,6 +10,15 @@ from kiwi_keg.keg import main
 
 from kiwi_keg.exceptions import KegError
 
+expected_list_output = """\
+Source                         Name                           Version  Description
+leap/15                        Leap15-JeOS                    1.0.42   Leap 15 guest image
+leap/15.1                      Leap15.1-JeOS                  1.0.42   Leap 15.1 guest image
+leap/15.2                      Leap15.2-JeOS                  1.0.42   Leap 15.2 guest image
+leap_no_overlays               Leap15-JeOS                    1.0.42   Leap 15 guest image
+leap_single_build              Leap15.2-JeOS                  1.0.42   Leap 15.2 guest image
+"""
+
 
 class TestKeg:
     @fixture(autouse=True)
@@ -101,23 +110,15 @@ class TestKeg:
                 main()
             assert 'Unexpected error' in self._caplog.text
 
-    @patch('kiwi_keg.keg.KegImageDefinition')
-    def test_keg_list_recipes(self, mock_KegImageDefinition):
+    def test_keg_list_recipes(self, capsys):
         sys.argv = [
             sys.argv[0], '--list-recipes',
             '--recipes-root', '../data'
         ]
-        image_definition = Mock()
-        image_definition.list_recipes.return_value = []
-        mock_KegImageDefinition.return_value = image_definition
         with self._caplog.at_level(logging.ERROR):
             main()
-            mock_KegImageDefinition.assert_called_once_with(
-                image_name='',
-                recipes_root='../data',
-                data_roots=[]
-            )
-            assert image_definition.list_recipes.called
+            cap = capsys.readouterr()
+            assert cap.out == expected_list_output
 
     @patch('pprint.pprint')
     @patch('kiwi_keg.keg.KegImageDefinition')


### PR DESCRIPTION
Instead of looking for directories with a image.yaml, try to construct an image definition from all leaf directories in 'images'. This adds basic validation of the image definitions.
Add image name, description, and version number to output.

The formatting uses hard-coded field widths, which isn't ideal, but "happens" to work well for images currently defined in keg-recipes. I can invest a little time in making it nicer if people think it's worth it.