### PR TITLE
Add documentation on keg recipes data strucutre

### DIFF
--- a/doc/source/commands/keg.rst
+++ b/doc/source/commands/keg.rst
@@ -11,7 +11,7 @@ SYNOPSIS
    keg (-l|--list-recipes) (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
 
    keg (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
-       [--format-xml|--format-yaml]
+       [--format-xml|--format-yaml] [--dump-dict]
        [-a ADD_DATA_ROOT] ... [-d DEST_DIR] [-fv]
        SOURCE
 
@@ -28,14 +28,14 @@ are situations where many image descriptions must be managed and the
 image descriptions have considerable overlap with respect to content
 and setup.
 
-The key component for Keg is a data structure called `image definition tree`.
+The key component for Keg is a data structure called `recipes`.
 This data structure is expected to contain all information necessary to
 create KIWI image descriptions. Keg is implemented such that data inheritance
-is possible to reduce data duplication in the `image definition tree`.
+is possible to reduce data duplication in the `recipes`.
 
-Please find an implementation of an `image definition tree` with
+Please find an implementation of an `recipes` with
 a focus on Public Cloud images here:
-`Public Cloud Image Definition Tree <https://github.com/SUSE-Enceladus/keg-recipes>`__
+`Public Cloud Keg Recipes <https://github.com/SUSE-Enceladus/keg-recipes>`__
 
 .. _keg_options:
 
@@ -91,6 +91,12 @@ OPTIONS
      written image description will be preserved into the
      formatted/updated KIWI XML file. Inline comments will
      not be preserved.
+
+--dump-dict
+
+  Parse input data and build image data dictionary, but instead
+  of running the generator, dump data dictionary and exit. Useful
+  for debugging.
 
 -v, --verbose
 

--- a/doc/source/commands/keg.rst
+++ b/doc/source/commands/keg.rst
@@ -20,22 +20,22 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-Keg is a tool which helps to create and manage image descriptions suitable
+`Keg` is a tool which helps to create and manage image descriptions suitable
 for the `KIWI <https://osinside.github.io/kiwi/>`__ appliance builder.
 While `keg` can be used to manage a single image definition the tool provides
-no considerable advantage in such a use case. The primary use case for keg
+no considerable advantage in such a use case. The primary use case for `keg`
 are situations where many image descriptions must be managed and the
 image descriptions have considerable overlap with respect to content
 and setup.
 
-The key component for Keg is a data structure called `recipes`.
-This data structure is expected to contain all information necessary to
-create KIWI image descriptions. Keg is implemented such that data inheritance
-is possible to reduce data duplication in the `recipes`.
+`Keg` requires source data called `recipes` which provides all information
+necessary for `keg` to create KIWI image descriptions. See
+:ref:`recipes_basics` for more information about `recipes`.
 
-Please find an implementation of an `recipes` with
-a focus on Public Cloud images here:
+The `recipes` used for generating SUSE Public Cloud image descriptions
+can be found in the
 `Public Cloud Keg Recipes <https://github.com/SUSE-Enceladus/keg-recipes>`__
+repository.
 
 .. _keg_options:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,7 +41,7 @@ default_role="py:obj"
 
 # General information about the project.
 project = 'Keg - Image Composition Tool'
-copyright = '2020, SUSE - Public Cloud Team'
+copyright = '2021, SUSE - Public Cloud Team'
 author = 'public-cloud-dev@suse.de'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/data_modules.rst
+++ b/doc/source/data_modules.rst
@@ -111,6 +111,13 @@ This section describes the input paramaters used by the data modules.
         - string
         ...
 
+.. note::
+
+  For multi-build image definitions, any module that defines `profile`
+  parameters must be included in the profile specific section of the image
+  definition. Inclusion in the `common` profile only works for single-build
+  image definitions.
+
 Namespace may be any name. Namespaces exist to allow for dictionaries to be
 merged without overwriting keys from inherited dictionaries, except where this
 is wanted. Using the same namespace in a more specific dictionary (i.e. a lower

--- a/doc/source/data_modules.rst
+++ b/doc/source/data_modules.rst
@@ -1,0 +1,159 @@
+.. _data_modules:
+
+Data Modules
+============
+
+Data modules are essentially directories in the :file:`data` tree. Inheritence
+rules apply similarly to the image definition tree, but additionally, `keg`
+supports cross inheritance for data modules. Cross inheritance is useful to
+inherit configuration changes from previous version. This can be specified in
+the image definition using the `include-paths` list. Include paths are paths
+the get appended to any source path and those get scanned for input files as
+well. For example, let's assume you have the following configration in your
+image defintion:
+
+.. code:: yaml
+
+  include-paths:
+    leap15/1
+    leap15/2
+  profiles:
+    common:
+      include:
+        base/common
+
+
+This tells `keg`, when adding data from directory :file:`data/base/common` to
+the image data dictionary, to also look into sub directories :file:`leap15/2`,
+:file:`leap15/1`, and :file:`leap15` (through inheritance). This would lead to
+the following directories being scanned::
+
+  data/common
+  data/common/base
+  data/common/base/leap15
+  data/common/base/leap15/1
+  data/common/base/leap15/2
+
+This allows for example to put generic configuration bits in
+:file:`common/base`, Leap 15 specific configuration in
+:file:`common/base/leap15`, and adjust the configuration for minor versions, if
+necessary.
+
+When building the dictionary, `keg` will parse all input files referenced
+in the `profiles` section and merge them into the main dictionary. The
+folliwing section describes the structure used in the data section.
+
+
+Data Module Dictionary Structure
+--------------------------------
+
+This section describes the input paramaters used by the data modules.
+
+.. note::
+
+   This assumes the schema template provided in the `keg-recipes repository
+   <https://github.com/SUSE-Enceladus/keg-recipes>`. Custom templates may
+   require different input data.
+
+.. code:: yaml
+
+  profile:
+    bootloader:
+      kiwi_bootloader_param: string
+      ...
+    parameters:
+      kiwi_peferences_type_param: string
+      ...
+      kernelcmdline:
+        kernel_param: value
+        kernel_multi_param: [value, value]
+        ...
+    size: integer
+  packages:
+    packages_type:
+      namespace:
+        - string
+        - name: string
+          arch: string
+  config:
+    files:
+      namespace:
+        - path: /path/to/file
+          append: bool
+          content: string
+        ...
+    scripts:
+      namespace:
+        - string
+        ....
+    sysconfig:
+      namespace:
+        - file: /etc/sysconfig/file
+          name: VARIABLE_NAME
+          value: VARIABLE_VALUE
+        ...
+    services:
+      namespace:
+        - string
+        - name: string
+          enable: bool
+        ...
+  setup:
+    (same as config)
+  overlayfiles:
+    namespace:
+      include:
+        - string
+        ...
+    namespace_named_archive:
+      archivename: string
+      include:
+        - string
+        ...
+
+Namespace may be any name. Namespaces exist to allow for dictionaries to be
+merged without overwriting keys from inherited dictionaries, except where this
+is wanted. Using the same namespace in a more specific dictionary (i.e. a lower
+level directory) can be used to change or even remove that namespace (for the
+latter set it to `Null`).
+
+`kiwi_bootloader_param` refers to any bootloader type parameter supported by
+`kiwi <https://documentation.suse.com/kiwi/9/html/kiwi/building-types.html#disk-bootloader>`__.
+
+`kiwi_peferences_type_param` refers to any preferences type parameter supported
+by `kiwi` (see `\<preferences\>\<type\> in kiwi documentation
+<https://documentation.suse.com/kiwi/9/html/kiwi/image-description.html#sec-preferences>`__).
+
+`kernelcmdline` is not a string that is directy copied into the appropriate
+`kiwi` parameter but a dictionary that defines kernel parameters individually,
+with each key representing a kernel parameter. This allows to inherit parts of
+the kernel command line from other modules. There are two notiations for
+parameters.  `kernel_param: value` will be translated into a single
+`kernel_param=value`, and `kernel_multi_param: [value, value, ...]` will add
+`kernel_multi_param` multiple times for each value from the given list.
+
+`packages_type` can be `bootstrap` or `image` (see `kiwi documentation
+<https://documentation.suse.com/kiwi/9/html/kiwi/image-description.html#sec-packages>`__).
+The items in the package list have two possible notations. Either just a plain
+string, which is considered to be the package name, or a dictionary with keys
+`name` (the package name) and `arch` (the build architecture for which the
+package should be included).
+
+List items in `config` `script` refer to files in :file:`data/scripts` (with
+:file:`.sh` appended by `keg`) and the content of those will be added to the
+:file:`config.sh` script.
+
+List items in `config` `services` refer to system service that should be
+enabled or disabled in the image. Analogue to packages, there are two supported
+version, a short one containing only the service name, or a long one that
+allows to specify whether the service should be enabled or disabled).
+
+`setup` has the same structure as `config` but the data will be used to
+generated :file:`images.sh` instead of :file:`config.sh`.
+
+List items in `overlayfiles` refer to directories under
+:file:`data/overlafiles`. Files from those directories will be copied into
+an overlay archive to be included in the image, either a generic or a profile
+specific one (depending on where the data module was included), or a named one
+in case `archivename` tag is used.
+

--- a/doc/source/data_modules.rst
+++ b/doc/source/data_modules.rst
@@ -3,12 +3,12 @@
 Data Modules
 ============
 
-Data modules are essentially directories in the :file:`data` tree. Inheritence
+Data modules are essentially directories in the :file:`data` tree. Inheritance
 rules apply similarly to the image definition tree, but additionally, `keg`
 supports cross inheritance for data modules. Cross inheritance is useful to
-inherit configuration changes from previous version. This can be specified in
+inherit configuration changes from previous versions. This can be specified in
 the image definition using the `include-paths` list. Include paths are paths
-the get appended to any source path and those get scanned for input files as
+that get appended to any source path and those get scanned for input files as
 well. For example, let's assume you have the following configration in your
 image defintion:
 

--- a/doc/source/data_modules.rst
+++ b/doc/source/data_modules.rst
@@ -9,8 +9,8 @@ supports cross inheritance for data modules. Cross inheritance is useful to
 inherit configuration changes from previous versions. This can be specified in
 the image definition using the `include-paths` list. Include paths are paths
 that get appended to any source path and those get scanned for input files as
-well. For example, let's assume you have the following configration in your
-image defintion:
+well. For example, let's assume you have the following configuration in your
+image definition:
 
 .. code:: yaml
 
@@ -41,13 +41,13 @@ necessary.
 
 When building the dictionary, `keg` will parse all input files referenced
 in the `profiles` section and merge them into the main dictionary. The
-folliwing section describes the structure used in the data section.
+following section describes the structure used in the data section.
 
 
 Data Module Dictionary Structure
 --------------------------------
 
-This section describes the input paramaters used by the data modules.
+This section describes the input parameters used by the data modules.
 
 .. note::
 
@@ -62,7 +62,7 @@ This section describes the input paramaters used by the data modules.
       kiwi_bootloader_param: string
       ...
     parameters:
-      kiwi_peferences_type_param: string
+      kiwi_preferences_type_param: string
       ...
       kernelcmdline:
         kernel_param: value
@@ -127,14 +127,14 @@ latter set it to `Null`).
 `kiwi_bootloader_param` refers to any bootloader type parameter supported by
 `kiwi <https://documentation.suse.com/kiwi/9/html/kiwi/building-types.html#disk-bootloader>`__.
 
-`kiwi_peferences_type_param` refers to any preferences type parameter supported
+`kiwi_preferences_type_param` refers to any preferences type parameter supported
 by `kiwi` (see `\<preferences\>\<type\> in kiwi documentation
 <https://documentation.suse.com/kiwi/9/html/kiwi/image-description.html#sec-preferences>`__).
 
-`kernelcmdline` is not a string that is directy copied into the appropriate
+`kernelcmdline` is not a string that is direct copied into the appropriate
 `kiwi` parameter but a dictionary that defines kernel parameters individually,
 with each key representing a kernel parameter. This allows to inherit parts of
-the kernel command line from other modules. There are two notiations for
+the kernel command line from other modules. There are two notations for
 parameters.  `kernel_param: value` will be translated into a single
 `kernel_param=value`, and `kernel_multi_param: [value, value, ...]` will add
 `kernel_multi_param` multiple times for each value from the given list.
@@ -159,7 +159,7 @@ allows to specify whether the service should be enabled or disabled).
 generated :file:`images.sh` instead of :file:`config.sh`.
 
 List items in `overlayfiles` refer to directories under
-:file:`data/overlafiles`. Files from those directories will be copied into
+:file:`data/overlayfiles`. Files from those directories will be copied into
 an overlay archive to be included in the image, either a generic or a profile
 specific one (depending on where the data module was included), or a named one
 in case `archivename` tag is used.

--- a/doc/source/image_definition.rst
+++ b/doc/source/image_definition.rst
@@ -22,7 +22,7 @@ definitions. Example directory layout::
                             image.yaml
 
 This example layout defines two images, `opensuse/leap/15.2` and
-`opensuse/leap/15.3`. It uses inheritence to define a common profile for both
+`opensuse/leap/15.3`. It uses inheritance to define a common profile for both
 image definitions, and to set some `opensuse` specific defaults. Running `keg
 -d output_dir opensuse/leap/15.3` would merge data from the following files in
 the show order::
@@ -86,8 +86,13 @@ dictionaries from a given input path need to have the following structure:
 
   Image definitions that define a `common` profile only in the `profiles`
   section are considered single-build and definitions with additional
-  profiles are considered multi-build. Again, this depends on the used
-  template and may not be true for custom templates.
+  profiles are considered multi-build. Single-build image descriptions
+  produce a single image binary, with all configuration properties included in
+  the `common` profile. Multi-build image descriptions produce an image binary
+  per profile, with each profile using all configuration properties included in
+  the corresponding profile section and the `common` profile. Since the
+  generated image description depends on the used template this may not apply
+  for custom templates.
 
 The `profiles` section is what defines the image configuration and data
 composition. Any list item in `include` refers to a directory under

--- a/doc/source/image_definition.rst
+++ b/doc/source/image_definition.rst
@@ -1,0 +1,94 @@
+.. _image_definition:
+
+Image Definition
+================
+
+`Keg` considers all leaf directories in :file:`images` to be image definitions.
+This means by parsing any yaml file from those directories and all yaml files
+in any parent directory and merging their data into a dictionary, a complete
+image definition needs to be available in the resulting dictionary. There is no
+specific hierarchy required in :file:`images`. You can use any level of sub
+directories to use any level of inheritance, or simply just to group image
+definitions. Example directory layout::
+
+  images/
+         opensuse/
+                  defaults.yaml
+                  leap/
+                       profiles.yaml
+                       15.2/
+                            image.yaml
+                       15.3/
+                            image.yaml
+
+This example layout defines two images, `opensuse/leap/15.2` and
+`opensuse/leap/15.3`. It uses inheritence to define a common profile for both
+image definitions, and to set some `opensuse` specific defaults. Running `keg
+-d output_dir opensuse/leap/15.3` would merge data from the following files in
+the show order::
+
+  images/opensuse/defaults.yaml
+  images/opensuse/leap/profiles.yaml
+  images/opensuse/leap/15.3/image.yaml
+
+Image Definition Structure
+--------------------------
+
+To properly define an image, the dictionary produced from merging the
+dictionaries from a given input path need to have the following structure:
+
+.. code:: yaml
+
+  archs:
+    - string
+    ...
+  include-paths:
+    - string
+    ...
+  image:
+    author: string
+    contact: string
+    name: string
+    specification: string
+    version: integer.integer.integer
+  profiles:
+    common:
+      include:
+        - string
+        ...
+    profile1:
+      include:
+        - string
+        ...
+    ...
+  schema: string
+  users:
+    - name: string
+      groups:
+        - string
+        ...
+      home: string
+      password: string
+    ...
+
+
+.. note::
+
+  `schema` corresponds to a template file in :file:`schema` (with
+  ``.kiwi.templ`` extension added). The schema defines the output structure and
+  hence the input structure is dependent on what schema is used.
+
+  Some of the listed dictionary items are not strictly required by keg but
+  they are used by the template provided in the `keg-recipes repository
+  <https://github.com/SUSE-Enceladus/keg-recipes>`__.
+
+.. note::
+
+  Image definitions that define a `common` profile only in the `profiles`
+  section are considered single-bulld and definitions with additional
+  profiles are considered multi-build. Again, this depends on the used
+  template and may not be true for custom templates.
+
+The `profiles` section is what defines the image configuration and data
+composition. Any list item in `include` refers to a directory under
+:file:`data`.

--- a/doc/source/image_definition.rst
+++ b/doc/source/image_definition.rst
@@ -85,7 +85,7 @@ dictionaries from a given input path need to have the following structure:
 .. note::
 
   Image definitions that define a `common` profile only in the `profiles`
-  section are considered single-bulld and definitions with additional
+  section are considered single-build and definitions with additional
   profiles are considered multi-build. Again, this depends on the used
   template and may not be true for custom templates.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,6 +12,9 @@ Keg Reference Guide
    overview
    installation
    commands
+   recipes_basics
+   image_definition
+   data_modules
 
 .. sidebar:: Links
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -20,12 +20,12 @@ are situations where many image descriptions must be managed and the
 image descriptions have considerable overlap with respect to content
 and setup.
 
-The key component for `keg` is a data structure called `image definition tree`.
+The key component for `keg` is a data structure called `recipes`.
 This data structure is expected to contain all information necessary to
 create KIWI image descriptions. `keg` is implemented such that data inheritance 
-is possible to reduce data duplication in the `image definition tree`.
+is possible to reduce data duplication in the `recipes`.
 
-The `image definition tree` consists of three major components:
+The `recipes` consist of three major components:
 
 Data Building Blocks: :file:`data`
   Independent collection of components used in KIWI image
@@ -44,10 +44,13 @@ Schema Templates: :file:`schemas`
   Templates to implement Syntax and Semantic of image description
   files as required by KIWI
 
-The setup of the `image definition tree` is the most time consuming
-part when using Keg. Example definitions for the `image definition tree`
+The setup of the `recipes` is the most time consuming
+part when using Keg. Example definitions for the `recipes`
 can be found here:
-`Public Cloud Image Definition Tree <https://github.com/SUSE-Enceladus/keg-recipes>`__
+`Public Cloud Keg Recipes <https://github.com/SUSE-Enceladus/keg-recipes>`__
+
+For more details on how `keg` processes `recipes` data, see section
+:ref:`recipes_basics` (ff).
 
 Working With Keg
 ----------------

--- a/doc/source/recipes_basics.rst
+++ b/doc/source/recipes_basics.rst
@@ -3,7 +3,7 @@
 Recipes Basics
 ==============
 
-To produce image descriptions, Keg must be provided with source data, also
+To produce image descriptions, keg must be provided with source data, also
 called `keg recipes`. Unlike kiwi descriptions, keg recipes can be composed of
 an arbitrary number of files, which allows to create building blocks for
 images. Keg does not mandate a specific structure of the recipes data, with the
@@ -18,7 +18,7 @@ Recipes Data Types
 
 There are several types of source data in `keg recipes`:
 
-1, Image Definitions
+1. Image Definitions
 
   Defines image properties and composition. Image definitions must be placed in
   the :file:`images` directory in the recipes root directory. Input format is
@@ -61,12 +61,12 @@ Source Data Format and Processing
 This section contains some general information about how `keg` handles its
 source data. An image description is internally represented by a data
 dictionary with a certain structure. This dictionary gets composed by parsing
-source image defintion and data files referenced by the image definition
+source image definition and data files referenced by the image definition
 and merging them into a dictionary. Image defintions as well as data modules
 are used by referencing a directory (under :file:`images` or :file:`data`
 respectively), which may be several layers of directories under the root
 directory. When parsing those, `keg` will also read any yaml file that is
 in a directory above the referenced one, and merge all source data into
 one dictionary, with the lower (i.e. more specific) layers taking precedence
-over upper (i.e. more generic) ones. This inhertance mechanism is intended to
+over upper (i.e. more generic) ones. This inheritance mechanism is intended to
 reduce data duplication.

--- a/doc/source/recipes_basics.rst
+++ b/doc/source/recipes_basics.rst
@@ -28,12 +28,12 @@ There are several types of source data in `keg recipes`:
 
 2. Data Specifications
 
-  Specifies profile paramaters, package lists, image setup configuration, and
-  overlay data configuation. Data specifications must be placed in the
+  Specifies profile parameters, package lists, image setup configuration, and
+  overlay data configuration. Data specifications must be placed in the
   :file:`data` directory. The sub directories :file:`data/scripts` and
   :file:`data/overlayfiles` are reserved for configuration scriptlets and
   overlay files (see below). Everything else under :file:`data` is considered
-  data module specficiation with input format `yaml`.
+  data module specification with input format `yaml`.
 
   2.1 Image Configuration Scripts
 
@@ -62,7 +62,7 @@ This section contains some general information about how `keg` handles its
 source data. An image description is internally represented by a data
 dictionary with a certain structure. This dictionary gets composed by parsing
 source image definition and data files referenced by the image definition
-and merging them into a dictionary. Image defintions as well as data modules
+and merging them into a dictionary. Image definitions as well as data modules
 are used by referencing a directory (under :file:`images` or :file:`data`
 respectively), which may be several layers of directories under the root
 directory. When parsing those, `keg` will also read any yaml file that is

--- a/doc/source/recipes_basics.rst
+++ b/doc/source/recipes_basics.rst
@@ -1,0 +1,72 @@
+.. _recipes_basics:
+
+Recipes Basics
+==============
+
+To produce image descriptions, Keg must be provided with source data, also
+called `keg recipes`. Unlike kiwi descriptions, keg recipes can be composed of
+an arbitrary number of files, which allows to create building blocks for
+images. Keg does not mandate a specific structure of the recipes data, with the
+exception that it expects certain types of source data in specific directories,
+but how you want to structure the data is up to you.
+
+This document describes the fundamental `keg recipes` structure and how `keg`
+processes input data to generate an image definition.
+
+Recipes Data Types
+------------------
+
+There are several types of source data in `keg recipes`:
+
+1, Image Definitions
+
+  Defines image properties and composition. Image definitions must be placed in
+  the :file:`images` directory in the recipes root directory. Input format is
+  `yaml`.
+
+  See :ref:`image_definition` for details.
+
+2. Data Specifications
+
+  Specifies profile paramaters, package lists, image setup configuration, and
+  overlay data configuation. Data specifications must be placed in the
+  :file:`data` directory. The sub directories :file:`data/scripts` and
+  :file:`data/overlayfiles` are reserved for configuration scriptlets and
+  overlay files (see below). Everything else under :file:`data` is considered
+  data module specficiation with input format `yaml`.
+
+  2.1 Image Configuration Scripts
+
+    Image descriptions may include configuration scripts, which `keg` can compose
+    from scriptlets. Those must be placed in :file:`data/scripts`. All files
+    need to have a `.sh` suffix. Format is `bash`.
+
+  2.2 Overlay Data
+
+    Image description may include overlay files that get copied into the target
+    image. `Keg` can create overlay archives from overlay data directories.
+    Those must be placed in :file:`data/overlayfiles`.
+
+  See :ref:`data_modules` for details on data modules.
+
+3. Schema Templates
+
+  `Keg` uses `jinja2` templates to produce the target `config.kiwi` file. The
+  template defines the output structure, which is provided with the full image
+  description as composed by `keg`. Templates need to be in :file:`data/schemas`.
+
+Source Data Format and Processing
+---------------------------------
+
+This section contains some general information about how `keg` handles its
+source data. An image description is internally represented by a data
+dictionary with a certain structure. This dictionary gets composed by parsing
+source image defintion and data files referenced by the image definition
+and merging them into a dictionary. Image defintions as well as data modules
+are used by referencing a directory (under :file:`images` or :file:`data`
+respectively), which may be several layers of directories under the root
+directory. When parsing those, `keg` will also read any yaml file that is
+in a directory above the referenced one, and merge all source data into
+one dictionary, with the lower (i.e. more specific) layers taking precedence
+over upper (i.e. more generic) ones. This inhertance mechanism is intended to
+reduce data duplication.


### PR DESCRIPTION
This PR adds sections `Recipes Basics`, `Image Definition`, and `Data Modules` which describe the fundamental data structure keg uses and how it merges data. The `Data Modules` part may be a bit hard to read, not sure. I thought it might be useful to have all specifications in one place rather than broken into several bits, but it means you'll probably have to scroll to see the explanation below. Feedback welcome.