### PR TITLE
documentation DC: Update to new suse2021 stylesheets

### DIFF
--- a/doc/DC-keg
+++ b/doc/DC-keg
@@ -4,5 +4,5 @@
 MAIN=xml/book.xml
 ADOC_POST=yes
 ADOC_TYPE=book
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
 DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"


### PR DESCRIPTION
As the SUSE doc team is currently updating all content on doc.suse.com to rebranded stylesheets, we'd like to update this repo to those stylesheets too.

Be aware that the new stylesheets are currently only officially available for SLE 15 SP3/Leap 15.3 and Tumbleweed. To use them in any other OS release, you currently still need to enable the Documentation:Tools OBS repo.

If that works for you, we'd be happy if this could be merged.

(Sorry about the branch name, I should not have used the web interface.)