### PR TITLE
Fix missing mypy library stubs

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -28,3 +28,4 @@ git+https://github.com/openSUSE/rstxml2docbook.git@feature/kiwi
 
 # Python static type checker
 mypy
+types-PyYAML


### PR DESCRIPTION
For static type checking many modules startet to create
library stubs packages to contain the types, like header
files in C/C++. This commit installs the missing stubs
package to the development environment