### PR TITLE
Nested profiles

### DIFF
--- a/kiwi_keg/file_utils.py
+++ b/kiwi_keg/file_utils.py
@@ -27,13 +27,13 @@ import yaml
 log = logging.getLogger('keg')
 
 
-def rmerge(src: Dict[str, str], dest: Dict[str, str]) -> Dict[str, str]:
+def rmerge(src: Dict[str, str], dest: Dict[str, str], ref: Dict[str, str] = None) -> Dict[str, str]:
     """
     Merge two dictionaries recursively,
     preserving all properties found in src.
     Updating 'dest' to the latest value, if property is not a dict
     or adding them in the right key, if it is while keeping the existing
-    key-values.
+    key-values. If 'ref' is given, only items _not_ in ref will be merged.
 
     Example:
     src = {'a': 'foo', 'b': {'c': 'bar'}}
@@ -42,14 +42,20 @@ def rmerge(src: Dict[str, str], dest: Dict[str, str]) -> Dict[str, str]:
     Result: {'a': 'foo', 'b': {'d': 'more_bar', 'c': 'bar'}}
     """
     for key, value in src.items():
+        ref_node = None
+        if ref:
+            ref_node = ref.get(key)
         if isinstance(value, dict):
             node = dest.setdefault(key, {})
-            rmerge(value, node)
-        elif value is None:
-            if dest.get(key):
+            rmerge(value, node, ref_node)
+            if not node:
                 del dest[key]
-        else:
-            dest[key] = value
+        elif ref_node is None:
+            if value is None:
+                if dest.get(key):
+                    del dest[key]
+            else:
+                dest[key] = value
     return dest
 
 

--- a/kiwi_keg/generator.py
+++ b/kiwi_keg/generator.py
@@ -214,7 +214,6 @@ class KegGenerator:
         for entry in entries:
             if os.path.join(subdir, entry.name) in [x.rstrip('/') for x in tar.getnames()]:
                 if entry.is_dir():
-                    print('dir already added')
                     self._add_dir_to_tar(tar, src_dir, os.path.join(subdir, entry.name))
                 else:
                     log.warning('{fname} included twice in {archive}'.format(

--- a/kiwi_keg/generator.py
+++ b/kiwi_keg/generator.py
@@ -209,10 +209,20 @@ class KegGenerator:
         tarinfo.uname = tarinfo.gname = 'root'
         return tarinfo
 
-    def _add_dir_to_tar(self, tar, src_dir):
-        entries = os.scandir(src_dir)
+    def _add_dir_to_tar(self, tar, src_dir, subdir=''):
+        entries = os.scandir(os.path.join(src_dir, subdir))
         for entry in entries:
-            tar.add(name=entry.path, arcname=entry.name, filter=self._tarinfo_set_root)
+            if os.path.join(subdir, entry.name) in [x.rstrip('/') for x in tar.getnames()]:
+                if entry.is_dir():
+                    print('dir already added')
+                    self._add_dir_to_tar(tar, src_dir, os.path.join(subdir, entry.name))
+                else:
+                    log.warning('{fname} included twice in {archive}'.format(
+                        fname=os.path.join(subdir, entry.name),
+                        archive=os.path.basename(tar.name))
+                    )
+            else:
+                tar.add(name=entry.path, arcname=os.path.join(subdir, entry.name), filter=self._tarinfo_set_root)
 
     def _copytree(self, src_dir, dest_dir):
         for entry in os.walk(src_dir):

--- a/kiwi_keg/script_utils.py
+++ b/kiwi_keg/script_utils.py
@@ -44,7 +44,11 @@ def get_config_script(profiles_dict: Dict, config_key: str, script_dirs: List[st
             continue
         config_root = profile_data.get(config_key)
         if config_root:
-            content += 'if [[ $kiwi_profiles = {profile} ]]; then\n'.format(profile=profile)
+            kiwi_profiles = profile_data.get('nested_profiles', [profile])
+            content += 'if [[ $kiwi_profiles = {} '.format(kiwi_profiles[0])
+            for p in kiwi_profiles[1:]:
+                content += '|| $kiwi_profiles = {} '.format(p)
+            content += ']]; then\n'
             content += get_profile_section(config_root, script_dirs, '    ')
             content += 'fi\n'
     return content

--- a/test/data/images/leap_nested_profiles/15.2/image.yaml
+++ b/test/data/images/leap_nested_profiles/15.2/image.yaml
@@ -1,0 +1,7 @@
+include-paths:
+  - leap15/1
+  - leap15/2
+image:
+  name: Leap15.2-JeOS
+  specification: "Leap 15.2 guest image"
+  version: 1.0.42

--- a/test/data/images/leap_nested_profiles/profiles.yaml
+++ b/test/data/images/leap_nested_profiles/profiles.yaml
@@ -1,0 +1,15 @@
+profiles:
+  common:
+    include:
+      - base/jeos
+  base:
+    include:
+      - foo_profile
+    one:
+      description: Some Profile
+      include:
+        - foo_profile/overlay-addon
+    other:
+      description: Some Other Profile
+      include:
+        - foo_profile/overlay-addon

--- a/test/unit/generator_test.py
+++ b/test/unit/generator_test.py
@@ -221,6 +221,25 @@ class TestKegGenerator:
             generator.create_overlays(False)
             assert not mock_shutil_copy.called
 
+    def test_add_dir_to_tar(self):
+        image_definition = KegImageDefinition(
+            image_name='leap/15.2', recipes_root='../data'
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir1_path = os.path.join(tmpdir, 'dir1')
+            dir2_path = os.path.join(tmpdir, 'dir2')
+            os.mkdir(dir1_path)
+            os.mkdir(dir2_path)
+            os.mkdir(os.path.join(dir1_path, 'etc'))
+            os.mkdir(os.path.join(dir2_path, 'etc'))
+            Path(os.path.join(dir1_path, 'etc', 'foo')).touch()
+            Path(os.path.join(dir2_path, 'etc', 'foo')).touch()
+            tar_path = os.path.join(tmpdir, 'tmp.tar')
+            generator = KegGenerator(image_definition, tmpdir)
+            with tarfile.open(tar_path, 'w') as tar:
+                generator._add_dir_to_tar(tar, dir1_path)
+                generator._add_dir_to_tar(tar, dir2_path)
+
     def test_tarinfo_set_root(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             some_file = os.path.join(tmpdir, 'some_file')

--- a/test/unit/keg_test.py
+++ b/test/unit/keg_test.py
@@ -15,6 +15,7 @@ Source                         Name                           Version  Descripti
 leap/15                        Leap15-JeOS                    1.0.42   Leap 15 guest image
 leap/15.1                      Leap15.1-JeOS                  1.0.42   Leap 15.1 guest image
 leap/15.2                      Leap15.2-JeOS                  1.0.42   Leap 15.2 guest image
+leap_nested_profiles/15.2      Leap15.2-JeOS                  1.0.42   Leap 15.2 guest image
 leap_no_overlays               Leap15-JeOS                    1.0.42   Leap 15 guest image
 leap_single_build              Leap15.2-JeOS                  1.0.42   Leap 15.2 guest image
 """


### PR DESCRIPTION
Add support for nested profiles in multi-build image definitions.
This potentially allows for shorter package sections, less duplication in overlay archives, and shorter config.sh scripts.
This commit also streamlines the produced overlay archives by not including directories multiple times.