### PR TITLE
Drop check for 'arch' key

### DIFF
--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -216,7 +216,6 @@ class KegImageDefinition:
         try:
             self._data['image']['name']
             self._data['image']['specification']
-            self._data['archs']
             self._data['profiles']
         except KeyError as err:
             raise KegError(


### PR DESCRIPTION
Do not require image definition dict to have an 'arch' key. Architecture build configuration is now handle via generic image config comments.

This is required for https://github.com/SUSE-Enceladus/keg-recipes/pull/40.