### PR TITLE
Handle errors in input data more gracefully

### DIFF
--- a/kiwi_keg/exceptions.py
+++ b/kiwi_keg/exceptions.py
@@ -56,3 +56,9 @@ class KegKiwiDescriptionError(KegError):
     Exception raised if the creation of the keg written description
     through the KIWI API has failed
     """
+
+
+class KegDataError(KegError):
+    """
+    Exception raised if input data contains errors.
+    """

--- a/kiwi_keg/file_utils.py
+++ b/kiwi_keg/file_utils.py
@@ -24,6 +24,8 @@ from typing import (
 import os
 import yaml
 
+from kiwi_keg.exceptions import KegDataError
+
 log = logging.getLogger('keg')
 
 
@@ -41,6 +43,11 @@ def rmerge(src: Dict[str, str], dest: Dict[str, str], ref: Dict[str, str] = None
 
     Result: {'a': 'foo', 'b': {'d': 'more_bar', 'c': 'bar'}}
     """
+    if type(src) != dict:
+        raise KegDataError('Cannot rmerge, source is not dict: {}'.format(src))
+    if type(dest) != dict:
+        raise KegDataError('Cannot rmerge, destination is not dict: {}'.format(dest))
+
     for key, value in src.items():
         ref_node = None
         if ref:

--- a/kiwi_keg/generator.py
+++ b/kiwi_keg/generator.py
@@ -24,7 +24,10 @@ import tarfile
 
 from kiwi_keg.image_definition import KegImageDefinition
 from kiwi_keg.kiwi_description import KiwiDescription
-from kiwi_keg.exceptions import KegError
+from kiwi_keg.exceptions import (
+    KegError,
+    KegDataError
+)
 
 from jinja2.exceptions import TemplateNotFound
 
@@ -69,7 +72,7 @@ class KegGenerator:
 
         self.image_schema: Optional[str] = self.image_definition.data.get('schema')
         if not self.image_schema:
-            raise KegError(
+            raise KegDataError(
                 'No KIWI schema configured in image definition'
             )
         log.info(
@@ -78,7 +81,7 @@ class KegGenerator:
             )
         )
         if not self.image_definition.data['image'].get('version'):
-            raise KegError('Keg Generator: image has no version')
+            raise KegDataError('Keg Generator: image has no version')
 
     def create_kiwi_description(self, overwrite: bool = False) -> None:
         """
@@ -264,7 +267,7 @@ class KegGenerator:
                 template_name
             )
         except TemplateNotFound:
-            raise KegError(
+            raise KegDataError(
                 'Template {name} not found in: {location}'.format(
                     name=repr(template_name),
                     location=self.description_schemas

--- a/test/unit/file_utils_test.py
+++ b/test/unit/file_utils_test.py
@@ -1,5 +1,7 @@
 from mock import patch
+from pytest import raises
 from kiwi_keg import file_utils
+from kiwi_keg.exceptions import KegDataError
 
 
 class TestUtils:
@@ -42,3 +44,11 @@ class TestUtils:
     def get_all_leaf_dirs(self, mock_os_walk):
         mock_os_walk.return_value = ['foo', [], []]
         assert file_utils.get_all_leaf_dirs('foo') == ['foo']
+
+    def test_rmerge_data_exception(self):
+        a_dict = {'some_key': 1}
+        not_a_dict = None
+        with raises(KegDataError):
+            file_utils.rmerge(a_dict, not_a_dict)
+        with raises(KegDataError):
+            file_utils.rmerge(not_a_dict, a_dict)


### PR DESCRIPTION
Check input objects for type before trying a dictionary rmerge.
Print error message instead of stack trace when image defintion populate fails.
Use separate exception for data errors.