### PR TITLE
Complete obs service

### DIFF
--- a/kiwi_keg/obs_service/compose_kiwi_description.service
+++ b/kiwi_keg/obs_service/compose_kiwi_description.service
@@ -18,4 +18,7 @@
   <parameter name="add-on-branch">
     <description>Branch in additional git source [default: released]</description>
   </parameter>
+  <parameter name="disable-version-bump">
+    <description>Do not increment the patch version number [default: False]</description>
+  </parameter>
 </service>

--- a/test/unit/obs_service/compose_kiwi_description_test.py
+++ b/test/unit/obs_service/compose_kiwi_description_test.py
@@ -1,5 +1,7 @@
-import logging
 import sys
+from mock import (
+    Mock, patch, call
+)
 from pytest import fixture
 from kiwi_keg.obs_service.compose_kiwi_description import main
 
@@ -22,6 +24,54 @@ class TestFetchFromKeg:
             'obs_out'
         ]
 
-    def test_compose_kiwi_description(self):
-        with self._caplog.at_level(logging.INFO):
-            main()
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Temporary.new_dir')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.KegImageDefinition')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.KegGenerator')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Command.run')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Path.create')
+    @patch('os.path.exists')
+    def test_compose_kiwi_description(
+        self, mock_path_exists, mock_Path_create, mock_Command_run,
+        mock_KegGenerator, mock_KegImageDefinition, mock_Temporary_new_dir
+    ):
+        mock_path_exists.return_value = False
+        image_definition = Mock()
+        mock_KegImageDefinition.return_value = image_definition
+        image_generator = Mock()
+        mock_KegGenerator.return_value = image_generator
+        temp_dir = Mock()
+        mock_Temporary_new_dir.return_value = temp_dir
+        main()
+        mock_Path_create.assert_called_once_with('obs_out')
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'git', 'clone',
+                    'https://github.com/SUSE-Enceladus/keg-recipes.git',
+                    temp_dir.name
+                ]
+            ),
+            call(
+                [
+                    'git', '-C', temp_dir.name, 'checkout', 'develop'
+                ]
+            )
+        ]
+        mock_KegImageDefinition.assert_called_once_with(
+            image_name='leap/jeos/15.2',
+            recipes_root=temp_dir.name,
+            data_roots=None,
+            image_version=None
+        )
+        mock_KegGenerator.assert_called_once_with(
+            image_definition=image_definition, dest_dir='obs_out'
+        )
+        image_generator.create_kiwi_description.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_custom_scripts.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_overlays.assert_called_once_with(
+            disable_root_tar=False, overwrite=True
+        )


### PR DESCRIPTION
This commit implements the actual keg call and store
of result image data in the output directory from
which OBS auto commits the data to the project if
called on the remote side. This Fixes #68