### PR TITLE
Use xmldiff to compare generated config.xml to expected

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -14,6 +14,7 @@ pytest-xdist
 
 # Rolling backport of unittest.mock for all Pythons
 mock
+xmldiff
 
 # Version-bump your software with a single command!
 bumpversion

--- a/test/unit/kiwi_description_test.py
+++ b/test/unit/kiwi_description_test.py
@@ -1,5 +1,6 @@
 import tempfile
 import filecmp
+from xmldiff import main
 from pytest import raises
 from mock import patch
 
@@ -35,9 +36,10 @@ class TestKiwiDescription:
         kiwi = KiwiDescription('../data/keg_output_xml/config.kiwi')
         with tempfile.NamedTemporaryFile() as tmpfile:
             kiwi.create_XML_description(tmpfile.name)
-            assert filecmp.cmp(
+            diff = main.diff_files(
                 '../data/keg_output_xml/config.xml', tmpfile.name
-            ) is True
+            )
+            assert len(diff) == 0
 
     def test_create_YAML_description(self):
         kiwi = KiwiDescription('../data/keg_output_yaml/config.kiwi')


### PR DESCRIPTION
Use xmldiff to compare generated config.xml to expected version instead of filecmp to avoid failing test due to immaterial differences in indentation.