### PR TITLE
Support multiple full recipes roots

### DIFF
--- a/kiwi_keg/generator.py
+++ b/kiwi_keg/generator.py
@@ -16,7 +16,7 @@
 # along with keg. If not, see <http://www.gnu.org/licenses/>
 #
 import logging
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, ChoiceLoader
 from typing import Optional
 import os
 import shutil
@@ -61,12 +61,12 @@ class KegGenerator:
             dest_dir, 'images.sh'
         )
         self.image_definition: KegImageDefinition = image_definition
-        self.description_schemas = os.path.join(
-            image_definition.recipes_root, 'schemas'
-        )
         self.dest_dir: str = dest_dir
+        loaders = []
+        for root in reversed(image_definition.recipes_roots):
+            loaders.append(FileSystemLoader(os.path.join(root, 'schemas')))
         self.env = Environment(
-            loader=FileSystemLoader(self.description_schemas)
+            loader=ChoiceLoader(loaders)
         )
 
         self.image_definition.populate()
@@ -260,8 +260,7 @@ class KegGenerator:
             )
         except TemplateNotFound:
             raise KegDataError(
-                'Template {name} not found in: {location}'.format(
-                    name=repr(template_name),
-                    location=self.description_schemas
+                'Template {name} not found'.format(
+                    name=repr(template_name)
                 )
             )

--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -66,7 +66,7 @@ class KegImageDefinition:
         for recipes_root in self._recipes_roots:
             if not os.path.isdir(recipes_root):
                 raise KegDataError(
-                    'Image Definition: {root} does not exist'.format(
+                    'Recipes root "{root}" does not exist'.format(
                         root=recipes_root
                     )
                 )
@@ -77,7 +77,7 @@ class KegImageDefinition:
                 break
         if not image_dir_exists:
             raise KegDataError(
-                'Image Definition: {image} does not exist'.format(
+                'Image source path "{image}" does not exist'.format(
                     image=self._image_name
                 )
             )

--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -63,24 +63,8 @@ class KegImageDefinition:
         self._data = self._dict_type({})
         self._config_script = None
         self._images_script = None
-        for recipes_root in self._recipes_roots:
-            if not os.path.isdir(recipes_root):
-                raise KegDataError(
-                    'Recipes root "{root}" does not exist'.format(
-                        root=recipes_root
-                    )
-                )
-        image_dir_exists = False
-        for image_dir in self._image_roots:
-            if os.path.isdir(os.path.join(image_dir, self._image_name)):
-                image_dir_exists = True
-                break
-        if not image_dir_exists:
-            raise KegDataError(
-                'Image source path "{image}" does not exist'.format(
-                    image=self._image_name
-                )
-            )
+        self._check_recipes_paths_exist()
+        self._check_image_path_exists()
 
     @property
     def data(self) -> keg_dict:
@@ -147,6 +131,28 @@ class KegImageDefinition:
         except Exception as issue:
             raise KegDataError(
                 'Error generating profile data: {error}'.format(error=issue)
+            )
+
+    def _check_recipes_paths_exist(self):
+        for recipes_root in self._recipes_roots:
+            if not os.path.isdir(recipes_root):
+                raise KegDataError(
+                    'Recipes root "{root}" does not exist'.format(
+                        root=recipes_root
+                    )
+                )
+
+    def _check_image_path_exists(self):
+        image_dir_exists = False
+        for image_dir in self._image_roots:
+            if os.path.isdir(os.path.join(image_dir, self._image_name)):
+                image_dir_exists = True
+                break
+        if not image_dir_exists:
+            raise KegDataError(
+                'Image source path "{image}" does not exist'.format(
+                    image=self._image_name
+                )
             )
 
     def _update_profiles(self):

--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -38,8 +38,7 @@ class KegImageDefinition:
     def __init__(
         self,
         image_name: str,
-        recipes_root: str,
-        data_roots: List[str] = [],
+        recipes_roots: List[str],
         image_version: str = None,
         archive_ext: str = 'tar.gz',
         track_sources: bool = False
@@ -47,12 +46,12 @@ class KegImageDefinition:
         """
         Init ImageDefintion with image_name and recipes root path
         """
-        self._recipes_root = recipes_root
+        self._recipes_roots = recipes_roots
         self._image_name = image_name
-        self._image_root = os.path.join(recipes_root, 'images')
+        self._image_roots = [os.path.join(x, 'images') for x in recipes_roots]
         self._image_version = image_version
-        self._data_roots = [os.path.join(recipes_root, 'data')]
-        self._overlay_root = os.path.join(recipes_root, 'data', 'overlayfiles')
+        self._data_roots = [os.path.join(x, 'data') for x in recipes_roots]
+        self._overlay_roots = [os.path.join(x, 'data', 'overlayfiles') for x in recipes_roots]
         self._archive_ext = archive_ext
         self._track_sources = track_sources
         self._dict_type: keg_dict_type
@@ -64,19 +63,22 @@ class KegImageDefinition:
         self._data = self._dict_type({})
         self._config_script = None
         self._images_script = None
-        if data_roots:
-            self._data_roots += data_roots
-        if not os.path.isdir(recipes_root):
-            raise KegDataError(
-                'Image Definition: {root} does not exist'.format(
-                    root=recipes_root
+        for recipes_root in self._recipes_roots:
+            if not os.path.isdir(recipes_root):
+                raise KegDataError(
+                    'Image Definition: {root} does not exist'.format(
+                        root=recipes_root
+                    )
                 )
-            )
-        image_dir = os.path.join(self._image_root, self._image_name)
-        if not os.path.isdir(image_dir):
+        image_dir_exists = False
+        for image_dir in self._image_roots:
+            if os.path.isdir(os.path.join(image_dir, self._image_name)):
+                image_dir_exists = True
+                break
+        if not image_dir_exists:
             raise KegDataError(
-                'Image Definition: {image_dir} does not exist'.format(
-                    image_dir=image_dir
+                'Image Definition: {image} does not exist'.format(
+                    image=self._image_name
                 )
             )
 
@@ -85,8 +87,8 @@ class KegImageDefinition:
         return self._data
 
     @property
-    def recipes_root(self) -> str:
-        return self._recipes_root
+    def recipes_roots(self) -> List[str]:
+        return self._recipes_roots
 
     @property
     def data_roots(self) -> List[str]:
@@ -97,8 +99,8 @@ class KegImageDefinition:
         return self._image_name
 
     @property
-    def image_root(self) -> str:
-        return self._image_root
+    def image_roots(self) -> List[str]:
+        return self._image_roots
 
     @property
     def archives(self) -> Optional[keg_dict]:
@@ -126,7 +128,7 @@ class KegImageDefinition:
         })
         try:
             img_dict = file_utils.get_recipes(
-                [self.image_root], [self.image_name], track_sources=self._track_sources
+                self.image_roots, [self.image_name], track_sources=self._track_sources
             )
             self._data.update(img_dict)
         except Exception as issue:

--- a/kiwi_keg/obs_service/compose_kiwi_description.py
+++ b/kiwi_keg/obs_service/compose_kiwi_description.py
@@ -74,7 +74,6 @@ def main() -> None:
             Command.run(['git', 'clone', repo, temp_git_dir.name])
         temp_git_dirs.append(temp_git_dir.name)
 
-    print(temp_git_dirs)
     image_definition = KegImageDefinition(
         image_name=args['--image-source'],
         recipes_roots=temp_git_dirs

--- a/test/unit/generator_test.py
+++ b/test/unit/generator_test.py
@@ -17,7 +17,7 @@ from kiwi_keg.exceptions import KegError
 class TestKegGenerator:
     def setup(self):
         self.image_definition = KegImageDefinition(
-            image_name='leap/15.2', recipes_root='../data'
+            image_name='leap/15.2', recipes_roots=['../data']
         )
 
     @patch('os.path.isdir')
@@ -214,7 +214,7 @@ class TestKegGenerator:
     @patch('shutil.copy')
     def test_create_no_overlays_configuration_provided(self, mock_shutil_copy):
         image_definition = KegImageDefinition(
-            image_name='leap_no_overlays', recipes_root='../data'
+            image_name='leap_no_overlays', recipes_roots=['../data']
         )
         with tempfile.TemporaryDirectory() as tmpdirname:
             generator = KegGenerator(image_definition, tmpdirname)
@@ -223,7 +223,7 @@ class TestKegGenerator:
 
     def test_add_dir_to_tar(self):
         image_definition = KegImageDefinition(
-            image_name='leap/15.2', recipes_root='../data'
+            image_name='leap/15.2', recipes_roots=['../data']
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             dir1_path = os.path.join(tmpdir, 'dir1')

--- a/test/unit/image_definition_test.py
+++ b/test/unit/image_definition_test.py
@@ -11,30 +11,21 @@ from kiwi_keg.exceptions import KegError
 class TestKegImageDefinition:
     def setup(self):
         self.keg_definition = KegImageDefinition(
-            image_name='leap/15.2', recipes_root='../data', image_version='1.0.42'
+            image_name='leap/15.2', recipes_roots=['../data'], image_version='1.0.42'
         )
-
-    def test_setup_with_additional_data_root(self):
-        keg_definition = KegImageDefinition(
-            image_name='leap/15.2', recipes_root='../data',
-            data_roots=['data2', 'data3']
-        )
-        assert keg_definition._data_roots == [
-            '../data/data', 'data2', 'data3'
-        ]
 
     def test_setup_raises_recipes_root_not_existing(self):
         with raises(KegError):
             KegImageDefinition(
-                image_name='leap/15.2', recipes_root='artificial'
+                image_name='leap/15.2', recipes_roots=['artificial']
             )
 
     def test_setup_raises_image_not_existing(self):
         with raises(KegError) as exception_info:
             KegImageDefinition(
-                image_name='no/such/image', recipes_root='../data'
+                image_name='no/such/image', recipes_roots=['../data']
             )
-        assert "Image Definition: ../data/images/no/such/image does not exist" in \
+        assert "Image Definition: no/such/image does not exist" in \
             str(exception_info.value)
 
     @patch('kiwi_keg.file_utils.get_recipes')
@@ -48,13 +39,13 @@ class TestKegImageDefinition:
     def test_populate_raises_on_no_such_overlay(self):
         with raises(KegError):
             keg_definition = KegImageDefinition(
-                image_name='leap_broken_overlay', recipes_root='../data'
+                image_name='leap_broken_overlay', recipes_roots=['../data']
             )
             keg_definition.populate()
 
     def test_generate_overlay_info_raises_on_broken_overlay(self):
         keg_definition = KegImageDefinition(
-            image_name='leap_broken_overlay', recipes_root='../data'
+            image_name='leap_broken_overlay', recipes_roots=['../data']
         )
         # produce in memory rather than read from data dir because
         # broken syntax in data tree would break list recipes cmd

--- a/test/unit/image_definition_test.py
+++ b/test/unit/image_definition_test.py
@@ -25,7 +25,7 @@ class TestKegImageDefinition:
             KegImageDefinition(
                 image_name='no/such/image', recipes_roots=['../data']
             )
-        assert "Image Definition: no/such/image does not exist" in \
+        assert 'Image source path "no/such/image" does not exist' in \
             str(exception_info.value)
 
     @patch('kiwi_keg.file_utils.get_recipes')

--- a/test/unit/keg_test.py
+++ b/test/unit/keg_test.py
@@ -45,8 +45,7 @@ class TestKeg:
             main()
             mock_KegImageDefinition.assert_called_once_with(
                 image_name='../data/images/leap/15.2',
-                recipes_root='../data',
-                data_roots=[],
+                recipes_roots=['../data'],
                 image_version='1.0.42',
                 track_sources=False
             )
@@ -82,8 +81,7 @@ class TestKeg:
             main()
             mock_KegImageDefinition.assert_called_once_with(
                 image_name='../data/images/leap/15.2',
-                recipes_root='../data',
-                data_roots=[],
+                recipes_roots=['../data'],
                 image_version='1.0.42',
                 track_sources=True
             )
@@ -183,8 +181,7 @@ class TestKeg:
             main()
             mock_KegImageDefinition.assert_called_once_with(
                 image_name='../data/images/leap/15.2',
-                recipes_root='../data',
-                data_roots=[],
+                recipes_roots=['../data'],
                 image_version=None,
                 track_sources=False
             )

--- a/test/unit/source_info_generator_test.py
+++ b/test/unit/source_info_generator_test.py
@@ -16,7 +16,7 @@ class TestSourceInfoGenerator:
 
     def setup(self):
         self.image_definition = KegImageDefinition(
-            image_name='leap/15.2', recipes_root='../data', track_sources=True
+            image_name='leap/15.2', recipes_roots=['../data'], track_sources=True
         )
 
     def test_write_source_info(self):
@@ -32,7 +32,7 @@ class TestSourceInfoGenerator:
 
     def test_write_source_info_single_build(self):
         self.image_definition = KegImageDefinition(
-            image_name='leap_single_build', recipes_root='../data', track_sources=True
+            image_name='leap_single_build', recipes_roots=['../data'], track_sources=True
         )
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.image_definition.populate()
@@ -46,7 +46,7 @@ class TestSourceInfoGenerator:
 
     def test_write_source_info_nested(self):
         self.image_definition = KegImageDefinition(
-            image_name='leap_nested_profiles/15.2', recipes_root='../data', track_sources=True
+            image_name='leap_nested_profiles/15.2', recipes_roots=['../data'], track_sources=True
         )
         with tempfile.TemporaryDirectory() as tmpdirname:
             self.image_definition.populate()


### PR DESCRIPTION
Instead of additional data roots only, support additional full recipes roots.
This allows to amend image definitions and add more schema templates.
Also changes obs_service to support arbitrary number of repos.