### PR TITLE
Support multiple roots for changelog generation

### DIFF
--- a/kiwi_keg/changelog_generator/generate_recipes_changelog.py
+++ b/kiwi_keg/changelog_generator/generate_recipes_changelog.py
@@ -20,7 +20,7 @@
 
 """
 Usage: generate_recipes_changelog [-o OUTPUT_FILE] [-r REV] [-f FORMAT]
-                                  [-m MSG_FORMAT] [-t ROOT_TAG] [-C PATH] LOGFILE
+                                  [-m MSG_FORMAT] [-t ROOT_TAG] LOGFILE
        generate_recipes_changelog -h | --help
 
 Arguments:
@@ -42,10 +42,6 @@ Options:
 
     -t ROOT_TAG
        Use ROOT_TAG for yaml output (e.g. image version)
-
-    -C PATH
-        Use PATH to git repository instead for current working dir.
-
 """
 
 import docopt
@@ -53,40 +49,38 @@ import subprocess
 import sys
 import yaml
 
-gitcmd = ['git']
-
 
 class MultiStr(str):
     pass
 
 
-def get_commits_from_range(start, end, filespec, rev=None):
-    cmdargs = gitcmd + ['log', '--no-merges', '--format=%ct %H', '--no-patch']
+def get_commits_from_range(start, end, filespec, gitroot, rev=None):
+    cmdargs = ['git', '-C', gitroot, 'log', '--no-merges', '--format=%ct %H', '--no-patch']
     if rev:
         cmdargs.append(rev)
     cmdargs += ['-L{start},{end}:{filespec}'.format(start=start, end=end, filespec=filespec)]
-    return get_commits(cmdargs)
+    return get_commits(cmdargs, gitroot)
 
 
-def get_commits_from_path(pathspec, rev=None):
-    cmdargs = gitcmd + ['log', '--no-merges', '--format=%ct %H']
+def get_commits_from_path(pathspec, gitroot, rev=None):
+    cmdargs = ['git', '-C', gitroot, 'log', '--no-merges', '--format=%ct %H']
     if rev:
         cmdargs.append(rev)
     cmdargs.append('--')
     cmdargs.append(pathspec)
-    return get_commits(cmdargs)
+    return get_commits(cmdargs, gitroot)
 
 
-def get_commits(gitargs):
+def get_commits(gitargs, gitroot):
     sp = subprocess.run(args=gitargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if sp.returncode != 0:
         raise Exception('git exited with error "{}"'.format(sp.stderr))
     commit_lines = sp.stdout.decode('utf-8').splitlines()
-    return set(tuple(x.split()) for x in commit_lines)
+    return set(tuple(x.split() + [gitroot]) for x in commit_lines)
 
 
-def get_commit_message(chash, msgformat):
-    gitargs = gitcmd + ['show', '--no-patch', '--format={}'.format(msgformat), chash]
+def get_commit_message(chash, gitroot, msgformat):
+    gitargs = ['git', '-C', gitroot, 'show', '--no-patch', '--format={}'.format(msgformat), chash]
     sp = subprocess.run(args=gitargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if sp.returncode != 0:
         raise Exception('git exited with error "{}"'.format(sp.stderr))
@@ -98,26 +92,34 @@ def repr_mstr(dumper, data):
     return dumper.represent_scalar(tag, data, style='|')
 
 
+def split_path(path, roots):
+    for r in roots:
+        if path.startswith(r):
+            return path[:len(r)], path[len(r) + 1:]
+    raise Exception('path "{}" is outside git roots'.format(path))
+
+
 def main():
     args = docopt.docopt(__doc__, version='0.1')
-    global gitcmd
 
     if args['-f'] not in ['text', 'yaml']:
         sys.exit('Unsupported output format "{}".'.format(args['-f']))
-
-    if args['-C']:
-        gitcmd += ['-C', args['-C']]
 
     with open(args['LOGFILE'], 'r') as inf:
         sources = inf.read().splitlines()
 
     commits = set()
+    roots = []
     for source in sources:
-        if source.startswith('range:'):
+        if source.startswith('root:'):
+            roots.append(source.split(':')[1])
+        elif source.startswith('range:'):
             rspec = source.split(':')
-            commits |= get_commits_from_range(rspec[1], rspec[2], rspec[3], args['-r'])
+            gitroot, fpath = split_path(rspec[3], roots)
+            commits |= get_commits_from_range(rspec[1], rspec[2], fpath, gitroot, args['-r'])
         else:
-            commits |= get_commits_from_path(source, args['-r'])
+            gitroot, fpath = split_path(source, roots)
+            commits |= get_commits_from_path(fpath, gitroot, args['-r'])
 
     if args['-o']:
         outp = open(args['-o'], 'w')
@@ -126,12 +128,12 @@ def main():
 
     if args['-f'] == 'text':
         for commit in sorted(commits, reverse=True):
-            print(get_commit_message(commit[1], args['-m']), file=outp)
+            print(get_commit_message(commit[1], commit[2], args['-m']), file=outp)
     else:
         msgs = []
         for commit in sorted(commits, reverse=True):
-            sub = get_commit_message(commit[1], '%s').lstrip('- ')
-            body = MultiStr(get_commit_message(commit[1], '%b').rstrip('\n'))
+            sub = get_commit_message(commit[1], commit[2], '%s').lstrip('- ')
+            body = MultiStr(get_commit_message(commit[1], commit[2], '%b').rstrip('\n'))
             if body:
                 msgs.append({'change': sub, 'details': body})
             else:

--- a/kiwi_keg/keg.py
+++ b/kiwi_keg/keg.py
@@ -17,8 +17,8 @@
 #
 """
 
-Usage: keg (-l|--list-recipes) (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT) ... [-v]
-       keg (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)
+Usage: keg (-l|--list-recipes) (-r RECIPES_ROOT|--recipes-root=RECIPES_ROOT)... [-v]
+       keg (-r RECIPES_ROOT|-recipes-root=RECIPES_ROOT)...
            [--format-xml|--format-yaml] [--disable-root-tar]
            [--disable-multibuild] [--dump-dict]
            [-i IMAGE_VERSION|--image-version=IMAGE_VERSION]
@@ -100,11 +100,14 @@ log.setLevel(logging.INFO)
 def main():
     args = docopt.docopt(__doc__, version=__version__)
 
+    # docopt seems to duplicate repeatable options, remove them
+    roots = list(dict.fromkeys(args['--recipes-root']))
+
     if args['--verbose']:
         log.setLevel(logging.DEBUG)
 
     if args['--list-recipes']:
-        image_roots = [os.path.join(x, 'images') for x in args['--recipes-root']]
+        image_roots = [os.path.join(x, 'images') for x in roots]
         image_dirs = []
         for image_root in image_roots:
             image_dirs += get_all_leaf_dirs(image_root)
@@ -113,7 +116,7 @@ def main():
             try:
                 image_definition = KegImageDefinition(
                     image_name=image_src,
-                    recipes_roots=args['--recipes-root']
+                    recipes_roots=roots
                 )
                 image_definition.populate()
                 image_spec = image_definition.data['image']
@@ -132,7 +135,7 @@ def main():
     try:
         image_definition = KegImageDefinition(
             image_name=args['SOURCE'],
-            recipes_roots=args['--recipes-root'],
+            recipes_roots=roots,
             image_version=args['--image-version'],
             track_sources=args['--write-source-info']
         )

--- a/kiwi_keg/source_info_generator.py
+++ b/kiwi_keg/source_info_generator.py
@@ -55,6 +55,8 @@ class SourceInfoGenerator:
         profiles = self.image_definition.data['profiles']
         if list(profiles.keys()) == ['common']:
             with self._open_source_info_file('log_sources', overwrite) as outf:
+                for r in self.image_definition.recipes_roots:
+                    outf.write('root:{}\n'.format(r))
                 outf.write(self._get_source_info_profile('common'))
                 outf.write('\n')
         else:
@@ -70,6 +72,8 @@ class SourceInfoGenerator:
                         with self._open_source_info_file(
                             'log_sources_{}'.format(nested_profile), overwrite
                         ) as outf:
+                            for r in self.image_definition.recipes_roots:
+                                outf.write('root:{}\n'.format(r))
                             outf.write(base_src_info)
                             outf.write('\n')
                             outf.write(self._get_source_info_profile(nested_profile))
@@ -78,6 +82,8 @@ class SourceInfoGenerator:
                     with self._open_source_info_file(
                         'log_sources_{}'.format(profile_name), overwrite
                     ) as outf:
+                        for r in self.image_definition.recipes_roots:
+                            outf.write('root:{}\n'.format(r))
                         outf.write(base_src_info)
                         outf.write('\n')
 

--- a/test/data/keg_output_source_info/log_sources
+++ b/test/data/keg_output_source_info/log_sources
@@ -1,3 +1,4 @@
+root:../data
 range:13:14:../data/images/leap_single_build/image.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2

--- a/test/data/keg_output_source_info/log_sources_broken
+++ b/test/data/keg_output_source_info/log_sources_broken
@@ -1,0 +1,2 @@
+root:some_root
+not_that_root/some_path

--- a/test/data/keg_output_source_info/log_sources_fake
+++ b/test/data/keg_output_source_info/log_sources_fake
@@ -1,2 +1,3 @@
-range:1:2:fake_range
-fake_path
+root:fake_root
+range:1:2:fake_root/fake_range
+fake_root/fake_path

--- a/test/data/keg_output_source_info/log_sources_nested_one
+++ b/test/data/keg_output_source_info/log_sources_nested_one
@@ -1,3 +1,4 @@
+root:../data
 range:4:5:../data/images/leap_nested_profiles/profiles.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2

--- a/test/data/keg_output_source_info/log_sources_nested_other
+++ b/test/data/keg_output_source_info/log_sources_nested_other
@@ -1,3 +1,4 @@
+root:../data
 range:4:5:../data/images/leap_nested_profiles/profiles.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2

--- a/test/data/keg_output_source_info/log_sources_other
+++ b/test/data/keg_output_source_info/log_sources_other
@@ -1,3 +1,4 @@
+root:../data
 range:4:5:../data/images/leap/profiles.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2

--- a/test/unit/changelog_generator/generate_recipes_changelog_test.py
+++ b/test/unit/changelog_generator/generate_recipes_changelog_test.py
@@ -44,7 +44,6 @@ class TestGenerateRecipesChangelog:
             sys.argv[0],
             '-r', 'fake_commit..',
             '-f', 'text',
-            '-C', '.',
             '../data/keg_output_source_info/log_sources_fake'
         ]
 
@@ -88,12 +87,12 @@ class TestGenerateRecipesChangelog:
     def test_get_commits_error(self):
         gitcmd = ['git', 'log', 'no_such_path']
         with raises(Exception) as err:
-            get_commits(gitcmd)
+            get_commits(gitcmd, 'fake_root')
         assert 'unknown revision or path not in the working tree' in str(err.value)
 
     def test_get_commit_message_error(self):
         with raises(Exception) as err:
-            get_commit_message('no_such_hash', '%s')
+            get_commit_message('no_such_hash', '.', '%s')
         assert 'unknown revision or path not in the working tree' in str(err.value)
 
     def test_unsupported_format_error(self):
@@ -101,3 +100,12 @@ class TestGenerateRecipesChangelog:
         with raises(SystemExit) as err:
             main()
         assert str(err.value) == 'Unsupported output format "foo".'
+
+    def test_broken_log(self):
+        sys.argv = [
+            sys.argv[0],
+            '../data/keg_output_source_info/log_sources_broken'
+        ]
+        with raises(Exception) as err:
+            main()
+        assert str(err.value) == 'path "not_that_root/some_path" is outside git roots'


### PR DESCRIPTION
This PR changes the source info generator to store the used recipes root directories in the generated logs, and the changelog generator to use that info to automatically select the appropriate path to the git repo. The previous implementation relied on the repo path to be supplied on the command line and didn't support multiple repositories.