### PR TITLE
Add support for change log generator to OBS source service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,6 @@ build: clean tox
 	$(python) setup.py sdist
 	# restore original setup.py backed up from sed
 	mv setup.pye setup.py
-	# provide rpm source tarball
-	mv dist/kiwi_keg-${version}.tar.gz dist/python-kiwi_keg.tar.gz
 	# update rpm changelog using reference file
 	helper/update_changelog.py --since package/python-kiwi_keg.changes > \
 		dist/python-kiwi_keg.changes

--- a/kiwi_keg/changelog_generator/generate_recipes_changelog.py
+++ b/kiwi_keg/changelog_generator/generate_recipes_changelog.py
@@ -19,7 +19,7 @@
 #
 
 """
-Usage: generate_recipes_changelog [-o OUTPUT_FILE] [-r REV] [-f FORMAT]
+Usage: generate_recipes_changelog [-o OUTPUT_FILE] [-r REV]... [-f FORMAT]
                                   [-m MSG_FORMAT] [-t ROOT_TAG] LOGFILE
        generate_recipes_changelog -h | --help
 
@@ -30,8 +30,8 @@ Options:
     -o OUTPUT_FILE
         Write output to OUTPUT_FILE
 
-    -r REV
-        Set git revision range start to REV
+    -r PATH:REV
+        Set git revision range start to REV for repo at PATH
 
     -f FORMAT
        Output format, 'text' or 'yaml' [default: yaml]
@@ -55,6 +55,8 @@ class MultiStr(str):
 
 
 def get_commits_from_range(start, end, filespec, gitroot, rev=None):
+    if rev == '':
+        return set()
     cmdargs = ['git', '-C', gitroot, 'log', '--no-merges', '--format=%ct %H', '--no-patch']
     if rev:
         cmdargs.append(rev)
@@ -63,6 +65,8 @@ def get_commits_from_range(start, end, filespec, gitroot, rev=None):
 
 
 def get_commits_from_path(pathspec, gitroot, rev=None):
+    if rev == '':
+        return set()
     cmdargs = ['git', '-C', gitroot, 'log', '--no-merges', '--format=%ct %H']
     if rev:
         cmdargs.append(rev)
@@ -87,6 +91,12 @@ def get_commit_message(chash, gitroot, msgformat):
     return sp.stdout.decode('utf-8').rstrip('\n')
 
 
+def git_log_empty(gitroot, rev):
+    cmdargs = ['git', '-C', gitroot, 'log', '--format=%H', '--no-patch', rev]
+    commits = get_commits(cmdargs, gitroot)
+    return commits == set()
+
+
 def repr_mstr(dumper, data):
     tag = u'tag:yaml.org,2002:str'
     return dumper.represent_scalar(tag, data, style='|')
@@ -94,9 +104,9 @@ def repr_mstr(dumper, data):
 
 def split_path(path, roots):
     for r in roots:
-        if path.startswith(r):
+        if path.startswith(r + '/'):
             return path[:len(r)], path[len(r) + 1:]
-    raise Exception('path "{}" is outside git roots'.format(path))
+    sys.exit('path "{}" is outside git roots'.format(path))
 
 
 def main():
@@ -108,6 +118,16 @@ def main():
     with open(args['LOGFILE'], 'r') as inf:
         sources = inf.read().splitlines()
 
+    revisions = {}
+    if args['-r']:
+        for r in args['-r']:
+            fields = r.split(':')
+            if len(fields) != 2:
+                sys.exit('Malformed revision specification "{}"'.format(r))
+            revisions[fields[0]] = fields[1]
+            if git_log_empty(*fields):
+                revisions[fields[0]] = ''
+
     commits = set()
     roots = []
     for source in sources:
@@ -116,10 +136,10 @@ def main():
         elif source.startswith('range:'):
             rspec = source.split(':')
             gitroot, fpath = split_path(rspec[3], roots)
-            commits |= get_commits_from_range(rspec[1], rspec[2], fpath, gitroot, args['-r'])
+            commits |= get_commits_from_range(rspec[1], rspec[2], fpath, gitroot, revisions.get(gitroot))
         else:
             gitroot, fpath = split_path(source, roots)
-            commits |= get_commits_from_path(fpath, gitroot, args['-r'])
+            commits |= get_commits_from_path(fpath, gitroot, revisions.get(gitroot))
 
     if args['-o']:
         outp = open(args['-o'], 'w')

--- a/kiwi_keg/obs_service/compose_kiwi_description.py
+++ b/kiwi_keg/obs_service/compose_kiwi_description.py
@@ -20,6 +20,8 @@ Usage:
     compose_kiwi_description --git-recipes=<git_clone_source> ... --image-source=<path> --outdir=<obs_out>
         [--git-branch=<name>] ...
         [--disable-version-bump]
+        [--disable-update-changelog]
+        [--disable-update-revisions]
     compose_kiwi_description -h | --help
     compose_kiwi_description --version
 
@@ -40,12 +42,23 @@ Options:
         this option is set.
 
     --disable-version-bump
-        Do not increment the patch version number
+        Do not increment the patch version number.
+
+    --disable-update-changelog
+        Do not update 'changes.yaml'.
+
+    --disable-update-revisions
+        Do not update '_keg_revisions'.
 """
-import os
+import glob
 import docopt
 import itertools
+import logging
+import os
+import re
+import shutil
 import sys
+import tempfile
 
 from kiwi.xml_description import XMLDescription
 from kiwi.utils.temporary import Temporary
@@ -54,6 +67,103 @@ from kiwi.path import Path
 from kiwi_keg.version import __version__
 from kiwi_keg.image_definition import KegImageDefinition
 from kiwi_keg.generator import KegGenerator
+from kiwi_keg.source_info_generator import SourceInfoGenerator
+
+
+log = logging.getLogger('compose_keg_description')
+
+
+def get_kiwi_data(kiwi_config):
+    description = XMLDescription(kiwi_config)
+    return description.load()
+
+
+def get_head_commit_hash(repo_path):
+    result = Command.run(['git', '-C', repo_path, 'show', '--no-patch', '--format=%H', 'HEAD'])
+    return result.output.strip('\n')
+
+
+def get_image_version(kiwi_config):
+    # It is expected that the <version> setting exists only once
+    # in a keg generated image description. KIWI allows for profiled
+    # <preferences> which in theory also allows to distribute the
+    # <version> information between several <preferences> sections
+    # but this would be in general questionable and should not be
+    # be done any case by keg managed recipes. Thus the following
+    # code takes the first version setting it can find and takes
+    # it as the only version information available
+    for preferences in get_kiwi_data(kiwi_config).get_preferences():
+        image_version = preferences.get_version()
+        if image_version:
+            return image_version[0]
+    if not image_version:
+        sys.exit('Cannot determine image version.')
+
+
+def get_revision_args(repo_dirs):
+    rev_args = []
+    if os.path.exists('_keg_revisions'):
+        with open('_keg_revisions') as inf:
+            for line in inf.readlines():
+                rev_spec = line.strip('\n').split(' ')
+                if len(rev_spec) != 2:
+                    sys.exit('Malformed revision spec "{}".'.format(line.strip('\n')))
+                repo_path = repo_dirs.get(rev_spec[0])
+                if not repo_path:
+                    log.warning('Warning: Cannot map URL "{}" to repository.'.format(rev_spec[0]))
+                else:
+                    rev_args += ['-r', '{}:{}..'.format(repo_path.name, rev_spec[1])]
+    else:
+        log.warning(
+            'Warning: no _keg_revision file. '
+            'Change file will contain all applicable commit messages.'
+        )
+    return rev_args
+
+
+def generate_changelog(source_log, outdir, prefix, image_version, rev_args):
+    prefix += '.' if prefix else ''
+    changes_new = os.path.join(outdir, '{}changes.yaml.tmp'.format(prefix))
+    changes_old = '{}changes.yaml'.format(prefix)
+    Command.run([
+        'generate_recipes_changelog',
+        '-o', changes_new,
+        '-f', 'yaml',
+        '-t', image_version,
+        *rev_args,
+        source_log
+    ])
+    if os.path.exists(changes_old):
+        with open(changes_new, 'a') as outf, open(changes_old) as inf:
+            outf.write(inf.read())
+    shutil.move(changes_new, os.path.join(outdir, changes_old))
+
+
+def update_image_version(kiwi_config, version):
+    # Do not use the kiwi export function to update XML data,
+    # as this would remove all comments from the file.
+    new_config = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    with open(kiwi_config, 'r') as inf:
+        exp = re.compile('(\\s*<version>)([^<]*)(</version>.*)')
+        line = inf.readline()
+        while line:
+            m = exp.match(line)
+            if m:
+                new_config.write(m.group(1))
+                new_config.write(version)
+                new_config.write(m.group(3))
+                new_config.write('\n')
+            else:
+                new_config.write(line)
+            line = inf.readline()
+    shutil.move(new_config.name, kiwi_config)
+
+
+def update_revisions(repo_dirs, outdir):
+    with open(os.path.join(outdir, '_keg_revisions'), 'w') as outf:
+        for rname, rpath in repo_dirs.items():
+            chash = get_head_commit_hash(rpath.name)
+            print('{} {}'.format(rname, chash), file=outf)
 
 
 def main() -> None:
@@ -65,18 +175,21 @@ def main() -> None:
     if len(args['--git-branch']) > len(args['--git-recipes']):
         sys.exit('Number of --git-branch arguments must not exceed number of git repos.')
 
-    temp_git_dirs = []
+    handle_changelog = not args['--disable-update-changelog']
+
+    repo_dirs = {}
     for repo, branch in itertools.zip_longest(args['--git-recipes'], args['--git-branch']):
         temp_git_dir = Temporary(prefix='keg_recipes.').new_dir()
         if branch:
             Command.run(['git', 'clone', '-b', branch, repo, temp_git_dir.name])
         else:
             Command.run(['git', 'clone', repo, temp_git_dir.name])
-        temp_git_dirs.append(temp_git_dir.name)
+        repo_dirs[repo] = temp_git_dir
 
     image_definition = KegImageDefinition(
         image_name=args['--image-source'],
-        recipes_roots=temp_git_dirs
+        recipes_roots=[x.name for x in repo_dirs.values()],
+        track_sources=handle_changelog
     )
     image_generator = KegGenerator(
         image_definition=image_definition,
@@ -92,24 +205,36 @@ def main() -> None:
         disable_root_tar=False, overwrite=True
     )
 
+    image_version = None
+    kiwi_config = f'{args["--outdir"]}/config.kiwi'
+
     if not args['--disable-version-bump']:
         # Increment patch version number unless disabled
-        kiwi_config = f'{args["--outdir"]}/config.kiwi'
-        description = XMLDescription(kiwi_config)
-        xml_data = description.load()
-        for preferences in xml_data.get_preferences():
-            # It is expected that the <version> setting exists only once
-            # in a keg generated image description. KIWI allows for profiled
-            # <preferences> which in theory also allows to distribute the
-            # <version> information between several <preferences> sections
-            # but this would be in general questionable and should not be
-            # be done any case by keg managed recipes. Thus the following
-            # code takes the first version setting it can find and takes
-            # it as the only version information available
-            if preferences.get_version():
-                version = preferences.get_version()[0].split('.')
-                version[2] = f'{int(version[2]) + 1}'
-                preferences.set_version(['.'.join(version)])
-                with open(kiwi_config, 'w') as kiwi:
-                    xml_data.export(outfile=kiwi, level=0)
-                break
+        version = get_image_version(kiwi_config)
+        if version:
+            ver_elements = version.split('.')
+            ver_elements[2] = f'{int(ver_elements[2]) + 1}'
+            image_version = '.'.join(ver_elements)
+            update_image_version(kiwi_config, image_version)
+
+    if handle_changelog:
+        sig = SourceInfoGenerator(image_definition, dest_dir=args['--outdir'])
+        sig.write_source_info()
+        rev_args = get_revision_args(repo_dirs)
+
+        if not image_version:
+            log.warning(
+                'Warning: generating changes file but version bump is disabled. '
+                'Using old version.'
+            )
+            image_version = get_image_version(kiwi_config)
+
+        for source_log in glob.glob(os.path.join(args['--outdir'], 'log_sources*')):
+            flavor = source_log[len(os.path.join(args['--outdir'], 'log_sources')) + 1:]
+            generate_changelog(source_log, args['--outdir'], flavor, image_version, rev_args)
+            # clean up source log
+            os.remove(source_log)
+
+    if not args['--disable-update-revisions']:
+        # capture current commits
+        update_revisions(repo_dirs, args['--outdir'])

--- a/kiwi_keg/obs_service/compose_kiwi_description.service
+++ b/kiwi_keg/obs_service/compose_kiwi_description.service
@@ -1,24 +1,24 @@
 <service name="compose_kiwi_description">
   <summary>Compose KIWI Image-Description from keg recipe</summary>
   <description>The service creates a KIWI description from a given keg recipe and commits it to the project</description>
-  <parameter name="main-git-recipes">
+  <parameter name="git-recipes">
     <description>Main git clone location to fetch keg recipes</description>
     <required/>
   </parameter>
-  <parameter name="main-branch">
+  <parameter name="branch">
     <description>Branch in main git source [default: released]</description>
   </parameter>
   <parameter name="image-source">
     <description>Keg path in git source pointing to the image description. The path must be relative to the images/ directory</description>
     <required/>
   </parameter>
-  <parameter name="add-on-git-recipes">
-    <description>Additional git clone location to fetch other keg recipes</description>
-  </parameter>
-  <parameter name="add-on-branch">
-    <description>Branch in additional git source [default: released]</description>
-  </parameter>
   <parameter name="disable-version-bump">
     <description>Do not increment the patch version number [default: False]</description>
+  </parameter>
+  <parameter name="disable-update-changelog">
+    <description>Do not update changes.yaml [default: False]</description>
+  </parameter>
+  <parameter name="disable-update-revisions">
+    <description>Do not update _keg_revisions [default: False]</description>
   </parameter>
 </service>

--- a/package/python-kiwi_keg-spec-template
+++ b/package/python-kiwi_keg-spec-template
@@ -53,7 +53,7 @@ License:        GPL-3.0-or-later
 Packager:       Public Cloud Team <public-cloud-dev@suse.de>
 %endif
 Group:          %{pygroup}
-Source:         %{name}.tar.gz
+Source:         kiwi_keg-%{version}.tar.gz
 Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python%{python3_pkgversion}-%{develsuffix}
@@ -86,6 +86,18 @@ Requires:       python%{python3_pkgversion}-cerberus
 %description -n python%{python3_pkgversion}-kiwi_keg
 KEG is an image composition tool for KIWI image descriptions
 
+%package -n obs-service-keg
+Summary:        An OBS service: generate KIWI description using KEG
+Group:          Development/Tools/Building
+Requires:       python%{python3_pkgversion}-kiwi_keg
+
+%description -n obs-service-keg
+This is a source service for openSUSE Build Service.
+
+The source service produces a KIWI image description through KEG from one or
+more given git repositories that contain keg-recipes source tree. It supports
+auto-generation of change log files from commit history.
+
 %prep
 %setup -q -n kiwi_keg-%{version}
 
@@ -106,11 +118,14 @@ make buildroot=%{buildroot}/ docdir=%{_defaultdocdir}/ install_package_docs
 %files -n python%{python3_pkgversion}-kiwi_keg
 %dir %{_defaultdocdir}/python-kiwi_keg
 %dir %{_usr}/lib/obs
+%{_bindir}/generate_recipes_changelog
 %{_bindir}/keg
-%{_usr}/lib/obs/service
 %{python3_sitelib}/kiwi_keg*
 %{_defaultdocdir}/python-kiwi_keg/LICENSE
 %{_defaultdocdir}/python-kiwi_keg/README
 %doc %{_mandir}/man8/*
+
+%files -n obs-service-keg
+%{_usr}/lib/obs/service
 
 %changelog

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ config = {
     'entry_points': {
         'console_scripts': [
             'keg=kiwi_keg.keg:main',
-            'compose_kiwi_description=kiwi_keg.obs_service.compose_kiwi_description:main'
+            'compose_kiwi_description=kiwi_keg.obs_service.compose_kiwi_description:main',
+            'generate_recipes_changelog=kiwi_keg.changelog_generator.generate_recipes_changelog:main'
         ]
     },
     'include_package_data': True,

--- a/test/unit/obs_service/compose_kiwi_description_test.py
+++ b/test/unit/obs_service/compose_kiwi_description_test.py
@@ -1,9 +1,19 @@
+import logging
+import os
 import sys
+import tempfile
 from mock import (
     Mock, patch, call
 )
 from pytest import fixture, raises
-from kiwi_keg.obs_service.compose_kiwi_description import main
+from kiwi_keg.obs_service.compose_kiwi_description import (
+    main,
+    generate_changelog,
+    get_image_version,
+    get_revision_args,
+    update_revisions,
+    update_image_version
+)
 
 
 class TestFetchFromKeg:
@@ -26,6 +36,13 @@ class TestFetchFromKeg:
             'obs_out'
         ]
 
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.update_image_version')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.update_revisions')
+    @patch('os.remove')
+    @patch('os.rename')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.get_revision_args')
+    @patch('glob.glob')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.SourceInfoGenerator')
     @patch('kiwi_keg.obs_service.compose_kiwi_description.XMLDescription')
     @patch('kiwi_keg.obs_service.compose_kiwi_description.Temporary.new_dir')
     @patch('kiwi_keg.obs_service.compose_kiwi_description.KegImageDefinition')
@@ -36,7 +53,9 @@ class TestFetchFromKeg:
     def test_compose_kiwi_description(
         self, mock_path_exists, mock_Path_create, mock_Command_run,
         mock_KegGenerator, mock_KegImageDefinition, mock_Temporary_new_dir,
-        mock_XMLDescription
+        mock_XMLDescription, mock_SourceInfoGenerator, mock_glob,
+        mock_get_revision_args, mock_rename, mock_remove,
+        mock_update_revisions, mock_update_image_version
     ):
         xml_data = Mock()
         preferences = Mock()
@@ -52,6 +71,11 @@ class TestFetchFromKeg:
         mock_KegGenerator.return_value = image_generator
         temp_dir = Mock()
         mock_Temporary_new_dir.return_value = temp_dir
+        source_info_generator = Mock()
+        mock_SourceInfoGenerator.return_value = source_info_generator
+        mock_glob.return_value = ['obs_out/log_sources_flavor1', 'obs_out/log_sources_flavor2']
+        mock_get_revision_args.return_value = ['-r', 'fake_repo:fake_rev..']
+        mock_path_exists.return_value = False
 
         with patch('builtins.open', create=True):
             main()
@@ -71,11 +95,32 @@ class TestFetchFromKeg:
                     'https://github.com/SUSE-Enceladus/keg-recipes2.git',
                     temp_dir.name
                 ]
+            ),
+            call(
+                [
+                    'generate_recipes_changelog',
+                    '-o', 'obs_out/flavor1.changes.yaml.tmp',
+                    '-f', 'yaml',
+                    '-t', '1.1.2',
+                    '-r', 'fake_repo:fake_rev..',
+                    'obs_out/log_sources_flavor1'
+                ]
+            ),
+            call(
+                [
+                    'generate_recipes_changelog',
+                    '-o', 'obs_out/flavor2.changes.yaml.tmp',
+                    '-f', 'yaml',
+                    '-t', '1.1.2',
+                    '-r', 'fake_repo:fake_rev..',
+                    'obs_out/log_sources_flavor2'
+                ]
             )
         ]
         mock_KegImageDefinition.assert_called_once_with(
             image_name='leap/jeos/15.2',
-            recipes_roots=[temp_dir.name, temp_dir.name]
+            recipes_roots=[temp_dir.name, temp_dir.name],
+            track_sources=True
         )
         mock_KegGenerator.assert_called_once_with(
             image_definition=image_definition, dest_dir='obs_out'
@@ -92,12 +137,212 @@ class TestFetchFromKeg:
         mock_XMLDescription.assert_called_once_with(
             'obs_out/config.kiwi'
         )
-        preferences.set_version.assert_called_once_with(
-            ['1.1.2']
+        mock_update_image_version.assert_called_once_with(
+            'obs_out/config.kiwi', '1.1.2'
         )
+        source_info_generator.write_source_info.assert_called_once()
+        mock_rename.assert_has_calls(
+            [
+                call('obs_out/flavor1.changes.yaml.tmp', 'obs_out/flavor1.changes.yaml'),
+                call('obs_out/flavor2.changes.yaml.tmp', 'obs_out/flavor2.changes.yaml')
+            ]
+        )
+        mock_remove.assert_has_calls(
+            [
+                call('obs_out/log_sources_flavor1'),
+                call('obs_out/log_sources_flavor2')
+            ]
+        )
+        mock_update_revisions.called_once_with([temp_dir.name, temp_dir.name])
+
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.update_revisions')
+    @patch('os.remove')
+    @patch('os.rename')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.get_revision_args')
+    @patch('glob.glob')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.SourceInfoGenerator')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.XMLDescription')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Temporary.new_dir')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.KegImageDefinition')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.KegGenerator')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Command.run')
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Path.create')
+    @patch('os.path.exists')
+    def test_compose_kiwi_description_no_version_bump(
+        self, mock_path_exists, mock_Path_create, mock_Command_run,
+        mock_KegGenerator, mock_KegImageDefinition, mock_Temporary_new_dir,
+        mock_XMLDescription, mock_SourceInfoGenerator, mock_glob,
+        mock_get_revision_args, mock_rename, mock_remove,
+        mock_update_revisions
+    ):
+        sys.argv = [
+            sys.argv[0],
+            '--git-recipes',
+            'https://github.com/SUSE-Enceladus/keg-recipes.git',
+            '--image-source',
+            'leap/jeos/15.2',
+            '--git-branch',
+            'develop',
+            '--outdir',
+            'obs_out',
+            '--disable-version-bump'
+        ]
+        xml_data = Mock()
+        preferences = Mock()
+        preferences.get_version.return_value = ['1.1.1']
+        xml_data.get_preferences.return_value = [preferences]
+        description = Mock()
+        description.load.return_value = xml_data
+        mock_XMLDescription.return_value = description
+        mock_path_exists.return_value = False
+        image_definition = Mock()
+        mock_KegImageDefinition.return_value = image_definition
+        image_generator = Mock()
+        mock_KegGenerator.return_value = image_generator
+        temp_dir = Mock()
+        mock_Temporary_new_dir.return_value = temp_dir
+        source_info_generator = Mock()
+        mock_SourceInfoGenerator.return_value = source_info_generator
+        mock_glob.return_value = ['obs_out/log_sources']
+        mock_get_revision_args.return_value = ['-r', 'fake_repo:fake_rev..']
+        mock_path_exists.return_value = False
+
+        with patch('builtins.open', create=True):
+            main()
+
+        mock_Path_create.assert_called_once_with('obs_out')
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'git', 'clone', '-b', 'develop',
+                    'https://github.com/SUSE-Enceladus/keg-recipes.git',
+                    temp_dir.name
+                ]
+            ),
+            call(
+                [
+                    'generate_recipes_changelog',
+                    '-o', 'obs_out/changes.yaml.tmp',
+                    '-f', 'yaml',
+                    '-t', '1.1.1',
+                    '-r', 'fake_repo:fake_rev..',
+                    'obs_out/log_sources'
+                ]
+            )
+        ]
+        mock_KegImageDefinition.assert_called_once_with(
+            image_name='leap/jeos/15.2',
+            recipes_roots=[temp_dir.name],
+            track_sources=True
+        )
+        mock_KegGenerator.assert_called_once_with(
+            image_definition=image_definition, dest_dir='obs_out'
+        )
+        image_generator.create_kiwi_description.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_custom_scripts.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_overlays.assert_called_once_with(
+            disable_root_tar=False, overwrite=True
+        )
+        mock_XMLDescription.assert_called_once_with(
+            'obs_out/config.kiwi'
+        )
+        preferences.set_version.assert_not_called()
+        source_info_generator.write_source_info.assert_called_once()
+        mock_rename.assert_has_calls(
+            [
+                call('obs_out/changes.yaml.tmp', 'obs_out/changes.yaml')
+            ]
+        )
+        mock_remove.assert_has_calls(
+            [
+                call('obs_out/log_sources'),
+            ]
+        )
+        mock_update_revisions.called_once_with([temp_dir.name, temp_dir.name])
 
     def test_too_many_branch_args(self):
         sys.argv += ['--git-branch=foo', '--git-branch=bar']
         with raises(SystemExit) as sysex:
             main()
         assert sysex.value.code == 'Number of --git-branch arguments must not exceed number of git repos.'
+
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Command.run')
+    def test_update_revisions(self, mock_run):
+        mock_dir = Mock()
+        mock_dir.name = 'fake_dir'
+        repos = {'fake_repo': mock_dir}
+        mock_result = Mock()
+        mock_result.output = '1234'
+        mock_run.return_value = mock_result
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            update_revisions(repos, tmpdirname)
+            mock_run.assert_called_once_with(
+                ['git', '-C', 'fake_dir', 'show', '--no-patch', '--format=%H', 'HEAD']
+            )
+            assert open(os.path.join(tmpdirname, '_keg_revisions'), 'r').read() == 'fake_repo 1234\n'
+
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.XMLDescription')
+    def test_image_version_error(self, mock_XMLDescription):
+        xml_data = Mock()
+        preferences = Mock()
+        preferences.get_version.return_value = None
+        xml_data.get_preferences.return_value = [preferences]
+        description = Mock()
+        description.load.return_value = xml_data
+        mock_XMLDescription.return_value = description
+        with raises(SystemExit) as sysex:
+            get_image_version(mock_XMLDescription)
+        assert sysex.value.code == 'Cannot determine image version.'
+
+    def test_get_revision_args(self):
+        mock_dir = Mock()
+        mock_dir.name = 'dir1'
+        repos = {'repo1': mock_dir}
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            with open(os.path.join(tmpdirname, '_keg_revisions'), 'w') as outf:
+                outf.write('repo1 hash1\nrepo2 hash2\n')
+
+            old_wd = os.getcwd()
+            os.chdir(tmpdirname)
+
+            with self._caplog.at_level(logging.WARNING):
+                get_revision_args(repos)
+                assert 'Warning: Cannot map URL "repo2" to repository.' in self._caplog.text
+
+            os.remove('_keg_revisions')
+            with self._caplog.at_level(logging.WARNING):
+                get_revision_args(repos)
+                assert 'Warning: no _keg_revision file.' in self._caplog.text
+
+            with open(os.path.join(tmpdirname, '_keg_revisions'), 'w') as outf:
+                outf.write('INVALID')
+
+            with raises(SystemExit) as sysex:
+                get_revision_args(repos)
+            assert sysex.value.code == 'Malformed revision spec "INVALID".'
+
+            os.chdir(old_wd)
+
+    @patch('kiwi_keg.obs_service.compose_kiwi_description.Command.run')
+    def test_changelog_prepend(self, mock_run):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            old_wd = os.getcwd()
+            os.chdir(tmpdirname)
+            open('changes.yaml', 'w').write('old entry\n')
+            open('changes.yaml.tmp', 'w').write('new entry\n')
+            generate_changelog('log_sources', tmpdirname, '', '1.1.1', (1, 2))
+            assert open('changes.yaml', 'r').read() == 'new entry\nold entry\n'
+            assert not os.path.exists('changes.yaml.tmp')
+            os.chdir(old_wd)
+
+    def test_update_image_version(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            kiwi_file = os.path.join(tmpdirname, 'config.kiwi')
+            open(kiwi_file, 'w').write('foo\n    <version>1.1.1</version>\n')
+            update_image_version(kiwi_file, '1.1.42')
+            assert open(kiwi_file, 'r').read() == 'foo\n    <version>1.1.42</version>\n'


### PR DESCRIPTION
This extends the OBS keg source service to support automatically updating the change log file. Change log is stored in `changes.yaml` for single-build and `$flavor.changes.yaml` for multi-build images. Applicable commit messages from the recipes repository or repositories are selected via keg's source tracking mechanism, and are limited by revision specification stored in the OBS package in `_keg_revisions`, which is automatically updated when a new change log is generated. This filters out old commit messages. Change logs added to the change log files are namespaced with the image version, which is automatically incremented at patch level. This can be disabled in case manually setting the version number is desired.