### PR TITLE
OBS service: abort on no source changes

### DIFF
--- a/kiwi_keg/obs_service/compose_kiwi_description.service
+++ b/kiwi_keg/obs_service/compose_kiwi_description.service
@@ -21,4 +21,7 @@
   <parameter name="disable-update-revisions">
     <description>Do not update _keg_revisions [default: False]</description>
   </parameter>
+  <parameter name="force">
+    <description>Refresh description even if there are no new commits [default: False]</description>
+  </parameter>
 </service>


### PR DESCRIPTION
Check start commit hashes from _keg_revisions against head commit hashes to determine whether the repositories have received new commits and abort if not. This allows the service to run regardless, without creating pointless version bumps.