### PR TITLE
fix: include top keys in source info tracking

### DIFF
--- a/test/data/keg_output_source_info/log_sources
+++ b/test/data/keg_output_source_info/log_sources
@@ -1,4 +1,13 @@
 root:../data
+range:1:1:../data/images/./defaults.yaml
+range:3:3:../data/images/./defaults.yaml
+range:4:4:../data/images/./defaults.yaml
+range:5:5:../data/images/leap_single_build/image.yaml
+range:6:6:../data/images/leap_single_build/image.yaml
+range:7:7:../data/images/leap_single_build/image.yaml
+range:9:10:../data/images/leap_single_build/image.yaml
+range:8:13:../data/images/./defaults.yaml
+range:2:4:../data/images/leap_single_build/image.yaml
 range:13:14:../data/images/leap_single_build/image.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2

--- a/test/data/keg_output_source_info/log_sources_nested_one
+++ b/test/data/keg_output_source_info/log_sources_nested_one
@@ -1,4 +1,13 @@
 root:../data
+range:1:1:../data/images/./defaults.yaml
+range:3:3:../data/images/./defaults.yaml
+range:4:4:../data/images/./defaults.yaml
+range:5:5:../data/images/leap_nested_profiles/15.2/image.yaml
+range:6:6:../data/images/leap_nested_profiles/15.2/image.yaml
+range:7:7:../data/images/leap_nested_profiles/15.2/image.yaml
+range:6:7:../data/images/./defaults.yaml
+range:8:13:../data/images/./defaults.yaml
+range:2:4:../data/images/leap_nested_profiles/15.2/image.yaml
 range:4:5:../data/images/leap_nested_profiles/profiles.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2

--- a/test/data/keg_output_source_info/log_sources_nested_other
+++ b/test/data/keg_output_source_info/log_sources_nested_other
@@ -1,4 +1,13 @@
 root:../data
+range:1:1:../data/images/./defaults.yaml
+range:3:3:../data/images/./defaults.yaml
+range:4:4:../data/images/./defaults.yaml
+range:5:5:../data/images/leap_nested_profiles/15.2/image.yaml
+range:6:6:../data/images/leap_nested_profiles/15.2/image.yaml
+range:7:7:../data/images/leap_nested_profiles/15.2/image.yaml
+range:6:7:../data/images/./defaults.yaml
+range:8:13:../data/images/./defaults.yaml
+range:2:4:../data/images/leap_nested_profiles/15.2/image.yaml
 range:4:5:../data/images/leap_nested_profiles/profiles.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2

--- a/test/data/keg_output_source_info/log_sources_other
+++ b/test/data/keg_output_source_info/log_sources_other
@@ -1,4 +1,13 @@
 root:../data
+range:1:1:../data/images/./defaults.yaml
+range:3:3:../data/images/./defaults.yaml
+range:4:4:../data/images/./defaults.yaml
+range:5:5:../data/images/leap/15.2/image.yaml
+range:6:6:../data/images/leap/15.2/image.yaml
+range:7:7:../data/images/leap/15.2/image.yaml
+range:6:7:../data/images/./defaults.yaml
+range:8:13:../data/images/./defaults.yaml
+range:2:4:../data/images/leap/15.2/image.yaml
 range:4:5:../data/images/leap/profiles.yaml
 range:4:7:../data/data/base/jeos/leap15/packages.yaml
 ../data/data/overlayfiles/products/leap/15.2


### PR DESCRIPTION
Include the source info for top level keys when generating source logs.