### PR TITLE
compose_kiwi_description: abort on empty change logs

### DIFF
--- a/kiwi_keg/changelog_generator/generate_recipes_changelog.py
+++ b/kiwi_keg/changelog_generator/generate_recipes_changelog.py
@@ -168,6 +168,9 @@ def main():
     if args['-o']:
         outp.close()
 
+    if not commits:
+        sys.exit(2)
+
 
 if __name__ == '__main__':
     main()  # pragma: no cover

--- a/kiwi_keg/obs_service/compose_kiwi_description.py
+++ b/kiwi_keg/obs_service/compose_kiwi_description.py
@@ -167,6 +167,8 @@ def generate_changelog(source_log, changes_file, image_version, rev_args):
     )
     if result.returncode == 1:
         sys.exit('Error generating change log: {}'.format(result.error))
+    # generate_recipes_changelog returns 2 in case there were no changes
+    # return True or False accordingly
     return result.returncode == 0
 
 

--- a/test/unit/changelog_generator/generate_recipes_changelog_test.py
+++ b/test/unit/changelog_generator/generate_recipes_changelog_test.py
@@ -84,7 +84,9 @@ class TestGenerateRecipesChangelog:
             tmpfile = os.path.join(tmpdir, 'out')
             sys.argv.append('-o')
             sys.argv.append(tmpfile)
-            main()
+            with raises(SystemExit) as sysex:
+                main()
+                assert sysex.value.code == 2
             assert open(tmpfile, 'r').read() == '[]\n'
 
     @patch('kiwi_keg.changelog_generator.generate_recipes_changelog.subprocess.run')


### PR DESCRIPTION
If the image does not have any changes (i.e. generated change logs for all flavors are empty), abort and delete all generated files.

The current implementation only detects if the repositories don't have new commits, but since most commits in `keg-recipes` are likely to only affect a subset of all images, this won't be enough to prevent unnecessary version bumps and rebuilds. This PR adds support to handle this situation properly.