### PR TITLE
OBS src service: write _multibuild file

### DIFF
--- a/kiwi_keg/obs_service/compose_kiwi_description.py
+++ b/kiwi_keg/obs_service/compose_kiwi_description.py
@@ -250,6 +250,7 @@ def main() -> None:
     image_generator.create_overlays(
         disable_root_tar=False, overwrite=True
     )
+    image_generator.create_multibuild_file(overwrite=True)
 
     if handle_changelog:
         sig = SourceInfoGenerator(image_definition, dest_dir=args['--outdir'])


### PR DESCRIPTION
Small fix in the OBS source service module to automatically generate a `_multibuild` file when appropriate.