### PR TITLE
require 'preferences' section to be a list

### DIFF
--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -123,9 +123,6 @@ class KegImageDefinition:
                 'Error parsing image data: {error}'.format(error=issue)
             )
 
-        if self._image_version:
-            self._data['image']['preferences'][0]['version'] = self._image_version
-
         try:
             self._expand_includes(self._data)
             if self._image_version:

--- a/kiwi_keg/image_schema.py
+++ b/kiwi_keg/image_schema.py
@@ -49,30 +49,24 @@ class ImageSchema:
                             }
                         }],
                     },
-                    'preferences': Or(
+                    'preferences': [
                         {
                             'version': And(str),
                         },
-                        [
+                        Optional(
                             {
-                                'version': And(str),
-                            },
-                            Optional(
-                                {
-                                    '_attributes': {
-                                        'profiles': [str],
-                                    },
-                                    'type': {
-                                        '_attributes': {
-                                            'image': And(str)
-                                        }
-                                    }
+                                '_attributes': {
+                                    'profiles': [str],
                                 },
-                                ignore_extra_keys=True
-                            )
-                        ],
-                        ignore_extra_keys=True
-                    ),
+                                'type': {
+                                    '_attributes': {
+                                        'image': And(str)
+                                    }
+                                }
+                            },
+                            ignore_extra_keys=True
+                        )
+                    ],
                     'repository': [
                         {
                             '_attributes': {

--- a/test/data/broken/images/broken-config/image.yaml
+++ b/test/data/broken/images/broken-config/image.yaml
@@ -10,7 +10,7 @@ image:
     contact: bob@example.net
     specification: "Leap 15.2 guest image"
   preferences:
-    version: 1.0.0
+    - version: 1.0.0
   packages:
     - _attributes:
         type: image

--- a/test/data/broken/images/broken-overlay/image.yaml
+++ b/test/data/broken/images/broken-overlay/image.yaml
@@ -10,7 +10,7 @@ image:
     contact: bob@example.net
     specification: "Leap 15.2 guest image"
   preferences:
-    version: 1.0.0
+    - version: 1.0.0
   packages:
     - _attributes:
         type: image

--- a/test/data/output/leap-jeos-single-platform/config.kiwi
+++ b/test/data/output/leap-jeos-single-platform/config.kiwi
@@ -11,12 +11,12 @@
         <specification>Leap 15.2 guest image</specification>
     </description>
     <preferences>
-        <version>1.0.0</version>
         <keytable>us.map.gz</keytable>
         <locale>en_US</locale>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <timezone>UTC</timezone>
+        <version>1.0.0</version>
     </preferences>
     <users>
         <user name="root" groups="root" home="/root" password="foo"/>

--- a/test/data/output/leap-jeos/config.kiwi
+++ b/test/data/output/leap-jeos/config.kiwi
@@ -16,12 +16,12 @@
         <profile name="Orange" description="Image for Orange Platform"/>
     </profiles>
     <preferences>
-        <version>1.0.0</version>
         <keytable>us.map.gz</keytable>
         <locale>en_US</locale>
         <packagemanager>zypper</packagemanager>
         <rpm-check-signatures>false</rpm-check-signatures>
         <timezone>UTC</timezone>
+        <version>1.0.0</version>
     </preferences>
     <preferences profiles="Blue">
         <type bootloader="grub2" bootpartition="false" firmware="efi" filesystem="xfs" format="vhd-fixed" image="vmx" kernelcmdline="console=ttyS0 console=tty1">


### PR DESCRIPTION
Drop support for 'preferences' to be list or dict. dict could be used for single-build image descriptions but it made the code a bit more complex in exchange for a very small convenience benefit.

Also setting the image version was broken for dict type 'preferences'.