### PR TITLE
Support multibuild parameter in src service

### DIFF
--- a/kiwi_keg/obs_service/compose_kiwi_description.py
+++ b/kiwi_keg/obs_service/compose_kiwi_description.py
@@ -25,6 +25,7 @@ Usage:
         [--update-changelogs=<true|false>]
         [--update-revisions=<true|false>]
         [--force=<true|false>]
+        [--generate-multibuild=<true|false>]
     compose_kiwi_description -h | --help
     compose_kiwi_description --version
 
@@ -67,6 +68,10 @@ Options:
     --force=<true|false>
         If true, refresh image description even if there are no new commits.
         [default: false]
+
+    --generate-multibuild=<true|false>
+        If true, generate a _multibuild file if the image definition has
+        profiles defined. [default: true]
 """
 import glob
 import docopt
@@ -266,7 +271,8 @@ def main() -> None:
     image_generator.create_overlays(
         disable_root_tar=False, overwrite=True
     )
-    image_generator.create_multibuild_file(overwrite=True)
+    if args['--generate-multibuild']:
+        image_generator.create_multibuild_file(overwrite=True)
 
     if handle_changelog:
         sig = SourceInfoGenerator(image_definition, dest_dir=args['--outdir'])

--- a/kiwi_keg/obs_service/compose_kiwi_description.service
+++ b/kiwi_keg/obs_service/compose_kiwi_description.service
@@ -31,4 +31,7 @@
   <parameter name="force">
     <description>If 'true' refresh image description even if there are no new commits [default: false]</description>
   </parameter>
+  <parameter name="generate-multibuild">
+    <description>If 'true', generate a _multibuild file if the image definition has profiles defined. [default: true]</description>
+  </parameter>
 </service>


### PR DESCRIPTION
Add support for setting generate multibuild file parameter to src service.

This can be useful if you want to use a custom `_multibuild` with your image description, for instance if you have a debug profile you don't necessarily want to build in all environments.