### PR TITLE
Drop rpmlintrc

### DIFF
--- a/package/python-kiwi_keg-rpmlintrc
+++ b/package/python-kiwi_keg-rpmlintrc
@@ -1,2 +1,0 @@
-# don't check for file duplicates
-addFilter("files-duplicate .*")

--- a/package/python-kiwi_keg-spec-template
+++ b/package/python-kiwi_keg-spec-template
@@ -54,7 +54,6 @@ Packager:       Public Cloud Team <public-cloud-dev@suse.de>
 %endif
 Group:          %{pygroup}
 Source:         kiwi_keg-%{version}.tar.gz
-Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python%{python3_pkgversion}-%{develsuffix}
 BuildRequires:  python%{python3_pkgversion}-Jinja2

--- a/package/python-kiwi_keg.spec
+++ b/package/python-kiwi_keg.spec
@@ -54,7 +54,6 @@ Packager:       Public Cloud Team <public-cloud-dev@suse.de>
 %endif
 Group:          %{pygroup}
 Source:         keg-%{version}.tar.gz
-Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python%{python3_pkgversion}-%{develsuffix}
 BuildRequires:  python%{python3_pkgversion}-Jinja2


### PR DESCRIPTION
Drop rpmlintrc disabling duplicate files check.

Generated egg info potentially contains two empty files (except for a newline) that triggers an rpmlint warning. This doesn't appear to happen in Tumbleweed which makes including the lintrc to produce an error. Not including it produces a warning in older distros. We could account for that but I think it's not worth it just to silence an rpmlint warning so we might as well drop it.