### PR TITLE
Use python 3.10 for publishing

### DIFF
--- a/.github/workflows/ci-publish-to-pypi.yml
+++ b/.github/workflows/ci-publish-to-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Since python 3.6 was dropped from ubuntu-latest, use 3.10 for the publishing pipeline.