### PR TITLE
Improve list command

### DIFF
--- a/kiwi_keg/image_definition.py
+++ b/kiwi_keg/image_definition.py
@@ -141,6 +141,22 @@ class KegImageDefinition:
                 'Error generating profile data: {error}'.format(error=issue)
             )
 
+    def populate_header(self) -> None:
+        """
+        Parse recipes data but only expand 'image: description'.
+        Used by list command for faster operation.
+        """
+        try:
+            img_dict = file_utils.get_recipes(
+                self.image_roots, [self.image_name], track_sources=self._track_sources
+            )
+            self._data.update(img_dict)
+            self._expand_includes(self._data['image']['description'])
+        except Exception as issue:
+            raise KegDataError(
+                'Error parsing image data: {error}'.format(error=issue)
+            )
+
     def _check_recipes_paths_exist(self):
         for recipes_root in self._recipes_roots:
             if not os.path.isdir(recipes_root):

--- a/kiwi_keg/keg.py
+++ b/kiwi_keg/keg.py
@@ -122,7 +122,7 @@ def main():
                     image_name=image_src,
                     recipes_roots=roots
                 )
-                image_definition.populate()
+                image_definition.populate_header()
                 image_spec = image_definition.data['image']
                 images[image_src] = {
                     'name': image_spec['_attributes']['name'],
@@ -130,10 +130,24 @@ def main():
                     'ver': image_spec['preferences'][0].get('version', 'n/a')
                 }
             except KegError as e:
-                log.error('{} is not a valid image: {}'.format(image_src, e))
-        print('{:30s} {:30s} {:8s} {}'.format('Source', 'Name', 'Version', 'Description'))
+                log.error('{} is not a valid image definition: {}'.format(image_src, e))
+            except KeyError as e:
+                log.error('{} is not a valid image definition, missing key "{}"'.format(image_src, e))
+
+        header = ['Source', 'Name', 'Version', 'Description']
+        max_src = len(header[0])
+        max_name = len(header[1])
+        max_ver = len(header[2])
+        max_desc = len(header[3])
         for image, spec in images.items():
-            print('{:30s} {:30s} {:8s} {}'.format(image, spec['name'], spec['ver'], spec['desc']))
+            max_src = len(image) if len(image) > max_src else max_src
+            max_name = len(spec['name']) if len(spec['name']) > max_name else max_name
+            max_ver = len(spec['ver']) if len(spec['ver']) > max_ver else max_ver
+            max_desc = len(spec['desc']) if len(spec['desc']) > max_desc else max_desc
+
+        print(f'{header[0]:{max_src}s} {header[1]:{max_name}s} {header[2]:{max_ver}s} {header[3]}')
+        for image, spec in images.items():
+            print(f'{image:{max_src}s} {spec["name"]:{max_name}s} {spec["ver"]:{max_ver}s} {spec["desc"]}')
         return
 
     try:

--- a/test/unit/keg_test.py
+++ b/test/unit/keg_test.py
@@ -11,12 +11,12 @@ from kiwi_keg.keg import main
 from kiwi_keg.exceptions import KegError
 
 expected_list_output = """\
-Source                         Name                           Version  Description
-leap-jeos-single-platform/15.1 Leap15.1-JeOS                  1.0.0    Leap 15.1 guest image
-leap-jeos-single-platform/15.2 Leap15.2-JeOS                  1.0.0    Leap 15.2 guest image
-leap-jeos/15.1                 Leap15.1-JeOS                  1.0.0    Leap 15.1 guest image
-leap-jeos/15.2                 Leap15.2-JeOS                  1.0.0    Leap 15.2 guest image
-missing-include/15.2           Leap15.2-JeOS                  1.0.0    Leap 15.2 guest image
+Source                         Name          Version Description
+leap-jeos-single-platform/15.1 Leap15.1-JeOS n/a     Leap 15.1 guest image
+leap-jeos-single-platform/15.2 Leap15.2-JeOS n/a     Leap 15.2 guest image
+leap-jeos/15.1                 Leap15.1-JeOS n/a     Leap 15.1 guest image
+leap-jeos/15.2                 Leap15.2-JeOS n/a     Leap 15.2 guest image
+missing-include/15.2           Leap15.2-JeOS n/a     Leap 15.2 guest image
 """
 
 
@@ -174,7 +174,7 @@ class TestKeg:
         ]
         with self._caplog.at_level(logging.ERROR):
             main()
-            assert 'is not a valid image' in self._caplog.text
+            assert 'is not a valid image definition' in self._caplog.text
 
     @patch('kiwi_keg.keg.AnnotatedPrettyPrinter')
     @patch('kiwi_keg.keg.KegImageDefinition')


### PR DESCRIPTION
Make list operation faster by not fully populating all image definitions. Find longest strings to output and size output fields accordingly for better format.

Note: This skips validation of image definitions, which with the number of image definitions in keg-recipes just takes way too long for a simple list command. The version number is also not necessarily available in the output (only when defined in `images/`, which for instance is not the case in keg-recipes), but I think that's ok and version numbers can be overwritten anyway.