### PR TITLE
Update change log handling

### DIFF
--- a/.coveragerc_py36
+++ b/.coveragerc_py36
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+      pragma: nocover
+      pragma: nocover_py36

--- a/.virtualenv.dev-requirements-py36.txt
+++ b/.virtualenv.dev-requirements-py36.txt
@@ -1,0 +1,8 @@
+#
+# Requirement files for Python 3.6 Virtual Development Environments
+#
+
+-r .virtualenv.dev-requirements.txt
+
+# Python <3.7 does not have datetime.formisoformat, so we use iso8601 module
+iso8601

--- a/kiwi_keg/tools/compose_kiwi_description.py
+++ b/kiwi_keg/tools/compose_kiwi_description.py
@@ -26,6 +26,8 @@ Usage:
         [--update-revisions=<true|false>]
         [--force=<true|false>]
         [--generate-multibuild=<true|false>]
+        [--new-image-change=<changelog_entry>]
+        [--changelog-format=<format>]
     compose_kiwi_description -h | --help
     compose_kiwi_description --version
 
@@ -72,18 +74,35 @@ Options:
     --generate-multibuild=<true|false>
         If true, generate a _multibuild file if the image definition has
         profiles defined. [default: true]
+
+    --new-image-change=<changelog_entry>
+        If set, when generating a net new image descriptions, use
+        changelog_entry as the sole entry in the generated change log instead
+        of using the full commit history. [default: None]
+
+    --changelog-format=<format>
+        Use format as output format for the generated change log. Supported
+        values are 'yaml', 'json', and 'osc'. Existing change logs will be
+        converted if necessary. Conversion from 'osc' is not supported.
+        [default: json]
+
+
 """
-import glob
 import docopt
+import glob
 import itertools
+import json
 import logging
 import os
+import pathlib
+import subprocess
 import sys
+import tempfile
+import yaml
+import xml.etree.ElementTree as ET
 
-from kiwi.xml_description import XMLDescription
-from kiwi.utils.temporary import Temporary
-from kiwi.command import Command
-from kiwi.path import Path
+from datetime import datetime, timezone
+
 from kiwi_keg.version import __version__
 from kiwi_keg.image_definition import KegImageDefinition
 from kiwi_keg.generator import KegGenerator
@@ -104,7 +123,7 @@ class RepoInfo:
         self._start_commit = commit
 
     @property
-    def path(self):
+    def pathname(self):
         return self._path.name
 
     @property
@@ -119,14 +138,20 @@ class RepoInfo:
         return self._start_commit != self._head_commit
 
 
-def get_kiwi_data(kiwi_config):
-    description = XMLDescription(kiwi_config)
-    return description.load()
+def repr_mstr(dumper, data):
+    if '\n' in data:
+        tag = u'tag:yaml.org,2002:str'
+        return dumper.represent_scalar(tag, data, style='|')
+    return dumper.represent_str(data)
 
 
 def get_head_commit_hash(repo_path):
-    result = Command.run(['git', '-C', repo_path, 'show', '--no-patch', '--format=%H', 'HEAD'])
-    return result.output.strip('\n')
+    result = subprocess.run(
+        ['git', '-C', repo_path, 'show', '--no-patch', '--format=%H', 'HEAD'],
+        capture_output=True,
+        encoding='UTF-8'
+    )
+    return result.stdout.strip('\n')
 
 
 def get_image_version(kiwi_config):
@@ -138,10 +163,12 @@ def get_image_version(kiwi_config):
     # be done any case by keg managed recipes. Thus the following
     # code takes the first version setting it can find and takes
     # it as the only version information available
-    for preferences in get_kiwi_data(kiwi_config).get_preferences():
-        image_version = preferences.get_version()
-        if image_version:
-            return image_version[0]
+    tree = ET.parse(kiwi_config)
+    root = tree.getroot()
+    for preferences in root.findall('preferences'):
+        image_version = preferences.find('version')
+        if image_version is not None:
+            return image_version.text
     if not image_version:
         sys.exit('Cannot determine image version.')
 
@@ -159,9 +186,8 @@ def parse_revisions(repos):
                 else:
                     repo.set_start_commit(rev_spec[1])
     else:
-        log.warning(
-            'No _keg_revision file. '
-            'Changes file(s) will contain all applicable commit messages.'
+        log.info(
+            'No _keg_revision file.'
         )
 
 
@@ -169,32 +195,98 @@ def get_revision_args(repos):
     rev_args = []
     for repo in repos.values():
         if repo.start_commit:
-            rev_args += ['-r', '{}:{}..'.format(repo.path, repo.start_commit)]
+            rev_args += ['-r', '{}:{}..'.format(repo.pathname, repo.start_commit)]
     return rev_args
 
 
-def generate_changelog(source_log, changes_file, image_version, rev_args):
-    result = Command.run(
+def generate_changelog(source_log, changes_file, log_format, image_version, rev_args):
+    result = subprocess.run(
         [
             'generate_recipes_changelog',
             '-o', changes_file,
-            '-f', 'yaml',
+            '-f', log_format,
             '-t', image_version,
             *rev_args,
             source_log
-        ], raise_on_error=False
+        ]
     )
     if result.returncode == 1:
-        sys.exit('Error generating change log: {}'.format(result.error))
+        sys.exit('Error generating change log.')
     # generate_recipes_changelog returns 2 in case there were no changes
     # return True or False accordingly
     return result.returncode == 0
 
 
-def update_changelog(changes_old, changes_new):
-    if os.path.exists(changes_old):
-        with open(changes_new, 'a') as outf, open(changes_old) as inf:
+def read_changelog(log_file):
+    changes = None
+    if log_file.endswith('.txt'):
+        with open(log_file, 'r') as inf:  # pragma: no cover
+            changes = inf.read()          # pragma: no cover
+    elif log_file.endswith('.yaml'):
+        with open(log_file, 'r') as inf:
+            changes = yaml.safe_load(inf)
+    elif log_file.endswith('.json'):
+        with open(log_file, 'r') as inf:
+            changes = json.load(inf)
+    else:
+        log.warning('Unsupported log format {}'.format(log_file))
+    return changes
+
+
+def update_changelog(log_file, log_format):
+    old_logs = glob.glob(pathlib.Path(log_file).stem + '.*')
+    if old_logs:
+        old_log = old_logs[0]
+        if len(old_logs) > 1:
+            log.warning('More than one format for old log, using {}'.format(old_log))
+    else:
+        log.info('No old log')
+        return
+
+    old_log_format = pathlib.Path(old_log).suffix[1:]
+    if old_log_format == 'txt':
+        old_log_format = 'osc'
+
+    if log_format != 'json' and log_format == old_log_format:
+        # simply concatenate old log to new one
+        with open(log_file, 'a') as outf, open(old_log) as inf:
+            log.info('Appending old changes to {}'.format(log_file))
             outf.write(inf.read())
+    else:
+        if old_log_format == 'osc':
+            log.warning('Converting text log files is not supported, losing history')
+            return
+        else:
+            # different formats, or both json which needs merge
+            log.info('Reading old changes from {}'.format(old_log))
+            old_changes = read_changelog(old_log)
+            if old_changes:
+                if log_format == 'osc':
+                    log.info('Appending old changes to {}'.format(pathlib.Path(log_file).name))
+                    write_changelog(log_file, log_format, old_changes, append=True)
+                else:
+                    new_changes = read_changelog(log_file)
+                    new_changes.update(old_changes)
+                    log.info('Writing merged changes to {}'.format(pathlib.Path(log_file).name))
+                    write_changelog(log_file, log_format, new_changes)
+
+
+def get_osc_log(ver, entries):
+    change = '-------------------------------------------------------------------\n'
+    if hasattr(datetime, 'fromisoformat'):
+        change += datetime.fromisoformat(entries[0]['date']).strftime('%c UTC')  # pragma: nocover_py36
+    else:
+        import iso8601  # pragma: nocover
+        change += iso8601.parse_date(entries[0]['date']).strftime('%c UTC')  # pragma: nocover
+    change += '\n'
+    indent = '- '
+    if ver:
+        change += '\n- Update to {}\n'.format(ver)
+        indent = '  + '
+    for entry in entries:
+        change += indent
+        change += '{}\n'.format(entry['change'])
+    return change
 
 
 def update_revisions(repos, outdir):
@@ -209,24 +301,47 @@ def get_log_sources(logdir):
         yield source_log, flavor
 
 
+def write_changelog(log_file, log_format, changes, append=False):
+    open_mode = 'w'
+    if append:
+        open_mode = 'a'
+    with open(log_file, open_mode) as outf:
+        if log_format == 'osc':
+            for image_version in changes:
+                if changes[image_version]:
+                    print(get_osc_log(image_version, changes[image_version]), file=outf)
+        elif log_format == 'yaml':
+            yaml.add_representer(str, repr_mstr, Dumper=yaml.SafeDumper)
+            yaml.safe_dump(changes, outf, sort_keys=False)
+        elif log_format == 'json':
+            json.dump(changes, outf, indent=2)
+
+
 def main() -> None:
     args = docopt.docopt(__doc__, version=__version__)
-
-    if not os.path.exists(args['--outdir']):
-        Path.create(args['--outdir'])
 
     if len(args['--git-branch']) > len(args['--git-recipes']):
         sys.exit('Number of --git-branch arguments must not exceed number of git repos.')
 
     handle_changelog = args['--update-changelogs'] == 'true'
 
+    if args['--changelog-format'] == 'osc':
+        log_ext = 'txt'
+    elif args['--changelog-format'] in ['yaml', 'json']:
+        log_ext = args['--changelog-format']
+    else:
+        sys.exit('Unknown changelog format {}'.format(args['--changelog-format']))
+
+    if not os.path.exists(args['--outdir']):
+        os.mkdir(args['--outdir'])
+
     repos = {}
     for repo, branch in itertools.zip_longest(args['--git-recipes'], args['--git-branch']):
-        temp_git_dir = Temporary(prefix='keg_recipes.').new_dir()
+        temp_git_dir = tempfile.TemporaryDirectory(prefix='keg_recipes.', dir='.')
         if branch:
-            Command.run(['git', 'clone', '-b', branch, repo, temp_git_dir.name])
+            subprocess.run(['git', 'clone', '-b', branch, repo, temp_git_dir.name])
         else:
-            Command.run(['git', 'clone', repo, temp_git_dir.name])
+            subprocess.run(['git', 'clone', repo, temp_git_dir.name])
         repos[repo] = RepoInfo(temp_git_dir)
 
     parse_revisions(repos)
@@ -251,9 +366,10 @@ def main() -> None:
                 ver_elements[2] = f'{int(ver_elements[2]) + 1}'
                 image_version = '.'.join(ver_elements)
 
+    logging.getLogger('keg').setLevel(logging.INFO)
     image_definition = KegImageDefinition(
         image_name=args['--image-source'],
-        recipes_roots=[x.path for x in repos.values()],
+        recipes_roots=[x.pathname for x in repos.values()],
         track_sources=handle_changelog,
         image_version=image_version
     )
@@ -283,25 +399,44 @@ def main() -> None:
         if not image_version:
             image_version = get_image_version(os.path.join(args['--outdir'], 'config.kiwi'))
 
-        for source_log, flavor in get_log_sources(os.path.join(args['--outdir'])):
-            changes_filename = f'{flavor}{"." if flavor else ""}changes.yaml'
-            changes_path = os.path.join(args['--outdir'], changes_filename)
-            have_changes |= generate_changelog(source_log, changes_path, image_version, rev_args)
+        if not old_kiwi_config and args['--new-image-change']:
+            # net new image, use supplied change log entry instead of generating
+            # full log from commit history
+            new_changes = {
+                image_version: [
+                    {
+                        'change': args['--new-image-change'],
+                        'date': datetime.now(timezone.utc).isoformat(timespec='minutes')
+                    }
+                ]
+            }
+            for source_log, flavor in get_log_sources(args['--outdir']):
+                changes_filename = f'{flavor}{"." if flavor else ""}changes.{log_ext}'
+                changes_path = os.path.join(args['--outdir'], changes_filename)
+                log.info('Writing {}'.format(changes_path))
+                write_changelog(changes_path, args['--changelog-format'], new_changes)
+                # clean up source log
+                os.remove(source_log)
+        else:
+            for source_log, flavor in get_log_sources(args['--outdir']):
+                changes_filename = f'{flavor}{"." if flavor else ""}changes.{log_ext}'
+                changes_path = os.path.join(args['--outdir'], changes_filename)
+                have_changes |= generate_changelog(source_log, changes_path, args['--changelog-format'], image_version, rev_args)
 
-        if not have_changes:
-            log.warning('Image has no changes.')
-            if args['--force'] != 'true':
-                log.info('Deleting generated files.')
-                for f in next(os.walk(args['--outdir']))[2]:
-                    os.remove(os.path.join(args['--outdir'], f))
-                sys.exit()
+            if not have_changes:
+                log.warning('Image has no changes.')
+                if args['--force'] != 'true':
+                    log.info('Deleting generated files.')
+                    for f in next(os.walk(args['--outdir']))[2]:
+                        os.remove(os.path.join(args['--outdir'], f))
+                    sys.exit()
 
-        for source_log, flavor in get_log_sources(os.path.join(args['--outdir'])):
-            changes_filename = f'{flavor}{"." if flavor else ""}changes.yaml'
-            changes_new = os.path.join(args['--outdir'], changes_filename)
-            update_changelog(changes_filename, changes_new)
-            # clean up source log
-            os.remove(source_log)
+            for source_log, flavor in get_log_sources(os.path.join(args['--outdir'])):
+                changes_filename = f'{flavor}{"." if flavor else ""}changes.{log_ext}'
+                changes_path = os.path.join(args['--outdir'], changes_filename)
+                update_changelog(changes_path, args['--changelog-format'])
+                # clean up source log
+                os.remove(source_log)
 
     if args['--update-revisions'] == 'true':
         # capture current commits

--- a/obs/compose_kiwi_description.service
+++ b/obs/compose_kiwi_description.service
@@ -23,7 +23,7 @@
     </description>
   </parameter>
   <parameter name="update-changelogs">
-    <description> Whether 'changes.yaml' files should be updated. [default: true]</description>
+    <description>Whether 'changes.yaml' files should be updated. [default: true]</description>
   </parameter>
   <parameter name="update-revisions">
     <description>Whether '_keg_revisions' should be updated. [default: true]</description>
@@ -33,5 +33,11 @@
   </parameter>
   <parameter name="generate-multibuild">
     <description>If 'true', generate a _multibuild file if the image definition has profiles defined. [default: true]</description>
+  </parameter>
+  <parameter name="new-image-changelog">
+    <description>If set, when generating a net new image descriptions, use changelog_entry as the sole entry in the generated change log instead of using the full commit history. [default: None]</description>
+  </parameter>
+  <parameter name="changelog-format">
+    <description>Set output format for generated change log. Supported values are 'yaml', 'json', and 'osc'. Existing change logs will be converted if necessary. Conversion from 'osc' is not supported.  [default: json]</description>
   </parameter>
 </service>

--- a/package/python-kiwi-keg.spec
+++ b/package/python-kiwi-keg.spec
@@ -43,6 +43,9 @@ Requires:       python-PyYAML
 Requires:       python-docopt
 Requires:       python-schema
 Requires:       python3-kiwi >= 9.21.21
+%if %python_version_nodots < 37
+Requires:       python-iso8601
+%endif
 %if %{with libalternatives}
 Requires:       alts
 BuildRequires:  alts

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ config = {
         'Jinja2',
         'kiwi>=9.21.21',
         'PyYAML',
-        'schema'
+        'schema',
+        'iso8601; python_version < "3.7.0"'
     ],
     'packages': ['kiwi_keg','kiwi_keg.tools'],
     'entry_points': {

--- a/test/unit/tools/compose_kiwi_description_test.py
+++ b/test/unit/tools/compose_kiwi_description_test.py
@@ -1,7 +1,9 @@
+import json
 import logging
 import os
 import sys
 import tempfile
+import yaml
 from unittest.mock import (
     Mock, patch, call
 )
@@ -16,6 +18,27 @@ from kiwi_keg.tools.compose_kiwi_description import (
     update_changelog,
     RepoInfo
 )
+
+
+fake_changes_txt_new = '''-------------------------------------------------------------------
+Fri May 12 16:37:47 2023 UTC
+
+- new entry
+
+'''
+
+fake_changes_txt_merged = '''-------------------------------------------------------------------
+Fri May 12 16:37:47 2023 UTC
+
+- new entry
+
+-------------------------------------------------------------------
+Thu May 11 09:41:50 2023 UTC
+
+- Update to 1.0
+  + old entry
+
+'''
 
 
 class TestFetchFromKeg:
@@ -38,51 +61,55 @@ class TestFetchFromKeg:
             'obs_out'
         ]
 
+    @patch('kiwi_keg.tools.compose_kiwi_description.update_changelog')
     @patch('kiwi_keg.tools.compose_kiwi_description.update_revisions')
     @patch('os.remove')
     @patch('kiwi_keg.tools.compose_kiwi_description.get_revision_args')
     @patch('glob.glob')
     @patch('kiwi_keg.tools.compose_kiwi_description.SourceInfoGenerator')
-    @patch('kiwi_keg.tools.compose_kiwi_description.XMLDescription')
-    @patch('kiwi_keg.tools.compose_kiwi_description.Temporary.new_dir')
+    @patch('kiwi_keg.tools.compose_kiwi_description.ET')
+    @patch('kiwi_keg.tools.compose_kiwi_description.tempfile.TemporaryDirectory')
     @patch('kiwi_keg.tools.compose_kiwi_description.KegImageDefinition')
     @patch('kiwi_keg.tools.compose_kiwi_description.KegGenerator')
-    @patch('kiwi_keg.tools.compose_kiwi_description.Command.run')
-    @patch('kiwi_keg.tools.compose_kiwi_description.Path.create')
+    @patch('kiwi_keg.tools.compose_kiwi_description.subprocess.run')
+    @patch('kiwi_keg.tools.compose_kiwi_description.os.mkdir')
     @patch('os.path.exists')
     def test_compose_kiwi_description(
-        self, mock_path_exists, mock_Path_create, mock_Command_run,
-        mock_KegGenerator, mock_KegImageDefinition, mock_Temporary_new_dir,
-        mock_XMLDescription, mock_SourceInfoGenerator, mock_glob,
-        mock_get_revision_args, mock_remove, mock_update_revisions
+        self, mock_path_exists, mock_mkdir, mock_subprocess_run,
+        mock_KegGenerator, mock_KegImageDefinition, mock_TemporaryDirectory,
+        mock_ET, mock_SourceInfoGenerator, mock_glob,
+        mock_get_revision_args, mock_remove, mock_update_revisions,
+        mock_update_changelog
     ):
-        xml_data = Mock()
-        preferences = Mock()
-        preferences.get_version.return_value = ['1.1.1']
-        xml_data.get_preferences.return_value = [preferences]
-        description = Mock()
-        description.load.return_value = xml_data
-        mock_XMLDescription.return_value = description
+        mock_tree = Mock()
+        mock_root = Mock()
+        mock_prefs = Mock()
+        mock_ver = Mock()
+        mock_ET.parse.return_value = mock_tree
+        mock_tree.getroot.return_value = mock_root
+        mock_root.findall.return_value = [mock_prefs]
+        mock_prefs.find.return_value = mock_ver
+        mock_ver.text = '1.1.1'
         mock_path_exists.side_effect = [False, False, True, True, True, False]
         image_definition = Mock()
         mock_KegImageDefinition.return_value = image_definition
         image_generator = Mock()
         mock_KegGenerator.return_value = image_generator
         temp_dir = Mock()
-        mock_Temporary_new_dir.return_value = temp_dir
+        mock_TemporaryDirectory.return_value = temp_dir
         source_info_generator = Mock()
         mock_SourceInfoGenerator.return_value = source_info_generator
         mock_glob.return_value = ['obs_out/log_sources_flavor1', 'obs_out/log_sources_flavor2']
         mock_get_revision_args.return_value = ['-r', 'fake_repo:fake_rev..']
         mock_result = Mock()
         mock_result.returncode = 0
-        mock_Command_run.return_value = mock_result
+        mock_subprocess_run.return_value = mock_result
 
         with patch('builtins.open', create=True):
             main()
 
-        mock_Path_create.assert_called_once_with('obs_out')
-        assert mock_Command_run.call_args_list == [
+        mock_mkdir.assert_called_once_with('obs_out')
+        assert mock_subprocess_run.call_args_list == [
             call(
                 [
                     'git', 'clone', '-b', 'develop',
@@ -94,7 +121,8 @@ class TestFetchFromKeg:
                 [
                     'git', '-C', temp_dir.name,
                     'show', '--no-patch', '--format=%H', 'HEAD'
-                ]
+                ],
+                capture_output=True, encoding='UTF-8'
             ),
             call(
                 [
@@ -107,27 +135,28 @@ class TestFetchFromKeg:
                 [
                     'git', '-C', temp_dir.name,
                     'show', '--no-patch', '--format=%H', 'HEAD'
+                ],
+                capture_output=True, encoding='UTF-8'
+            ),
+            call(
+                [
+                    'generate_recipes_changelog',
+                    '-o', 'obs_out/flavor1.changes.json',
+                    '-f', 'json',
+                    '-t', '1.1.2',
+                    '-r', 'fake_repo:fake_rev..',
+                    'obs_out/log_sources_flavor1'
                 ]
             ),
             call(
                 [
                     'generate_recipes_changelog',
-                    '-o', 'obs_out/flavor1.changes.yaml',
-                    '-f', 'yaml',
-                    '-t', '1.1.2',
-                    '-r', 'fake_repo:fake_rev..',
-                    'obs_out/log_sources_flavor1'
-                ], raise_on_error=False
-            ),
-            call(
-                [
-                    'generate_recipes_changelog',
-                    '-o', 'obs_out/flavor2.changes.yaml',
-                    '-f', 'yaml',
+                    '-o', 'obs_out/flavor2.changes.json',
+                    '-f', 'json',
                     '-t', '1.1.2',
                     '-r', 'fake_repo:fake_rev..',
                     'obs_out/log_sources_flavor2'
-                ], raise_on_error=False
+                ]
             )
         ]
         mock_KegImageDefinition.assert_called_once_with(
@@ -148,7 +177,7 @@ class TestFetchFromKeg:
         image_generator.create_overlays.assert_called_once_with(
             disable_root_tar=False, overwrite=True
         )
-        mock_XMLDescription.assert_called_once_with(
+        mock_ET.parse.assert_called_once_with(
             'config.kiwi'
         )
         assert mock_remove.call_args_list == [
@@ -157,6 +186,10 @@ class TestFetchFromKeg:
         ]
         source_info_generator.write_source_info.assert_called_once()
         mock_update_revisions.assert_called_once()
+        assert mock_update_changelog.call_args_list == [
+            call('obs_out/flavor1.changes.json', 'json'),
+            call('obs_out/flavor2.changes.json', 'json')
+        ]
 
     @patch('kiwi_keg.tools.compose_kiwi_description.update_revisions')
     @patch('os.walk')
@@ -164,17 +197,17 @@ class TestFetchFromKeg:
     @patch('kiwi_keg.tools.compose_kiwi_description.get_revision_args')
     @patch('glob.glob')
     @patch('kiwi_keg.tools.compose_kiwi_description.SourceInfoGenerator')
-    @patch('kiwi_keg.tools.compose_kiwi_description.XMLDescription')
-    @patch('kiwi_keg.tools.compose_kiwi_description.Temporary.new_dir')
+    @patch('kiwi_keg.tools.compose_kiwi_description.ET')
+    @patch('tempfile.TemporaryDirectory')
     @patch('kiwi_keg.tools.compose_kiwi_description.KegImageDefinition')
     @patch('kiwi_keg.tools.compose_kiwi_description.KegGenerator')
-    @patch('kiwi_keg.tools.compose_kiwi_description.Command.run')
-    @patch('kiwi_keg.tools.compose_kiwi_description.Path.create')
+    @patch('kiwi_keg.tools.compose_kiwi_description.subprocess.run')
+    @patch('os.mkdir')
     @patch('os.path.exists')
     def test_compose_kiwi_description_no_version_bump(
-        self, mock_path_exists, mock_Path_create, mock_Command_run,
-        mock_KegGenerator, mock_KegImageDefinition, mock_Temporary_new_dir,
-        mock_XMLDescription, mock_SourceInfoGenerator, mock_glob,
+        self, mock_path_exists, mock_mkdir, mock_subprocess_run,
+        mock_KegGenerator, mock_KegImageDefinition, mock_TemporaryDirectory,
+        mock_ET, mock_SourceInfoGenerator, mock_glob,
         mock_get_revision_args, mock_remove, mock_walk, mock_update_revisions
     ):
         sys.argv = [
@@ -187,29 +220,32 @@ class TestFetchFromKeg:
             'develop',
             '--outdir',
             'obs_out',
-            '--version-bump=false'
+            '--version-bump=false',
+            '--changelog-format=yaml'
         ]
-        xml_data = Mock()
-        preferences = Mock()
-        preferences.get_version.return_value = ['1.1.1']
-        xml_data.get_preferences.return_value = [preferences]
-        description = Mock()
-        description.load.return_value = xml_data
-        mock_XMLDescription.return_value = description
+        mock_tree = Mock()
+        mock_root = Mock()
+        mock_prefs = Mock()
+        mock_ver = Mock()
+        mock_ET.parse.return_value = mock_tree
+        mock_tree.getroot.return_value = mock_root
+        mock_root.findall.return_value = [mock_prefs]
+        mock_prefs.find.return_value = mock_ver
+        mock_ver.text = '1.1.1'
         mock_path_exists.side_effect = [False, True, True, True]
         image_definition = Mock()
         mock_KegImageDefinition.return_value = image_definition
         image_generator = Mock()
         mock_KegGenerator.return_value = image_generator
         temp_dir = Mock()
-        mock_Temporary_new_dir.return_value = temp_dir
+        mock_TemporaryDirectory.return_value = temp_dir
         source_info_generator = Mock()
         mock_SourceInfoGenerator.return_value = source_info_generator
         mock_glob.return_value = ['obs_out/log_sources']
         mock_get_revision_args.return_value = ['-r', 'fake_repo:fake_rev..']
         mock_result = Mock()
         mock_result.returncode = 2
-        mock_Command_run.return_value = mock_result
+        mock_subprocess_run.return_value = mock_result
         mock_walk.return_value = iter([('obs_out', [], ['config.kiwi'])])
 
         with patch('builtins.open', create=True), raises(SystemExit), self._caplog.at_level(logging.WARNING):
@@ -217,8 +253,8 @@ class TestFetchFromKeg:
 
         assert 'Image has no changes.' in self._caplog.text
 
-        mock_Path_create.assert_called_once_with('obs_out')
-        assert mock_Command_run.call_args_list == [
+        mock_mkdir.assert_called_once_with('obs_out')
+        assert mock_subprocess_run.call_args_list == [
             call(
                 [
                     'git', 'clone', '-b', 'develop',
@@ -230,7 +266,8 @@ class TestFetchFromKeg:
                 [
                     'git', '-C', temp_dir.name,
                     'show', '--no-patch', '--format=%H', 'HEAD'
-                ]
+                ],
+                capture_output=True, encoding='UTF-8'
             ),
             call(
                 [
@@ -240,7 +277,7 @@ class TestFetchFromKeg:
                     '-t', '1.1.1',
                     '-r', 'fake_repo:fake_rev..',
                     'obs_out/log_sources'
-                ], raise_on_error=False
+                ]
             )
         ]
         mock_KegImageDefinition.assert_called_once_with(
@@ -261,12 +298,267 @@ class TestFetchFromKeg:
         image_generator.create_overlays.assert_called_once_with(
             disable_root_tar=False, overwrite=True
         )
-        mock_XMLDescription.assert_called_once_with(
+        mock_ET.parse.assert_called_once_with(
             'obs_out/config.kiwi'
         )
-        preferences.set_version.assert_not_called()
         source_info_generator.write_source_info.assert_called_once()
         mock_remove.assert_called_once_with('obs_out/config.kiwi')
+
+    @patch('kiwi_keg.tools.compose_kiwi_description.datetime')
+    @patch('kiwi_keg.tools.compose_kiwi_description.write_changelog')
+    @patch('kiwi_keg.tools.compose_kiwi_description.update_revisions')
+    @patch('os.remove')
+    @patch('kiwi_keg.tools.compose_kiwi_description.get_revision_args')
+    @patch('glob.glob')
+    @patch('kiwi_keg.tools.compose_kiwi_description.SourceInfoGenerator')
+    @patch('kiwi_keg.tools.compose_kiwi_description.ET')
+    @patch('tempfile.TemporaryDirectory')
+    @patch('kiwi_keg.tools.compose_kiwi_description.KegImageDefinition')
+    @patch('kiwi_keg.tools.compose_kiwi_description.KegGenerator')
+    @patch('kiwi_keg.tools.compose_kiwi_description.subprocess.run')
+    @patch('os.mkdir')
+    @patch('os.path.exists')
+    def test_compose_kiwi_description_new_image(
+        self, mock_path_exists, mock_mkdir, mock_subprocess_run,
+        mock_KegGenerator, mock_KegImageDefinition, mock_TemporaryDirectory,
+        mock_ET, mock_SourceInfoGenerator, mock_glob,
+        mock_get_revision_args, mock_remove, mock_update_revisions,
+        mock_write_changelog, mock_datetime
+    ):
+        sys.argv = [
+            sys.argv[0],
+            '--git-recipes',
+            'https://github.com/SUSE-Enceladus/keg-recipes.git',
+            '--image-source',
+            'leap/jeos/15.2',
+            '--git-branch',
+            'develop',
+            '--outdir',
+            'obs_out',
+            '--version-bump=false',
+            '--changelog-format=json',
+            '--new-image-change=new image'
+        ]
+        mock_tree = Mock()
+        mock_root = Mock()
+        mock_prefs = Mock()
+        mock_ver = Mock()
+        mock_ET.parse.return_value = mock_tree
+        mock_tree.getroot.return_value = mock_root
+        mock_root.findall.return_value = [mock_prefs]
+        mock_prefs.find.return_value = mock_ver
+        mock_ver.text = '1.1.1'
+        mock_path_exists.side_effect = [False, False, False, True]
+        image_definition = Mock()
+        mock_KegImageDefinition.return_value = image_definition
+        image_generator = Mock()
+        mock_KegGenerator.return_value = image_generator
+        temp_dir = Mock()
+        mock_TemporaryDirectory.return_value = temp_dir
+        source_info_generator = Mock()
+        mock_SourceInfoGenerator.return_value = source_info_generator
+        mock_glob.return_value = ['obs_out/log_sources']
+        mock_get_revision_args.return_value = ['-r', 'fake_repo:fake_rev..']
+        mock_result = Mock()
+        mock_result.returncode = 2
+        mock_subprocess_run.return_value = mock_result
+        mock_timestamp = Mock()
+        mock_timestamp.isoformat.return_value = 'TIMESTAMP'
+        mock_datetime.now.return_value = mock_timestamp
+
+        with patch('builtins.open', create=True):
+            main()
+
+        mock_mkdir.assert_called_once_with('obs_out')
+        assert mock_subprocess_run.call_args_list == [
+            call(
+                [
+                    'git', 'clone', '-b', 'develop',
+                    'https://github.com/SUSE-Enceladus/keg-recipes.git',
+                    temp_dir.name
+                ]
+            ),
+            call(
+                [
+                    'git', '-C', temp_dir.name,
+                    'show', '--no-patch', '--format=%H', 'HEAD'
+                ],
+                capture_output=True, encoding='UTF-8'
+            )
+        ]
+        mock_KegImageDefinition.assert_called_once_with(
+            image_name='leap/jeos/15.2',
+            recipes_roots=[temp_dir.name],
+            track_sources=True,
+            image_version=None
+        )
+        mock_KegGenerator.assert_called_once_with(
+            image_definition=image_definition, dest_dir='obs_out', archs=[]
+        )
+        image_generator.create_kiwi_description.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_custom_scripts.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_overlays.assert_called_once_with(
+            disable_root_tar=False, overwrite=True
+        )
+        mock_ET.parse.assert_called_once_with(
+            'obs_out/config.kiwi'
+        )
+        source_info_generator.write_source_info.assert_called_once()
+        mock_remove.assert_called_once_with('obs_out/log_sources')
+        expected_changelog = {'1.1.1': [{'change': 'new image', 'date': 'TIMESTAMP'}]}
+        mock_write_changelog.assert_called_once_with(
+            'obs_out/changes.json',
+            'json',
+            expected_changelog
+        )
+
+    @patch('kiwi_keg.tools.compose_kiwi_description.update_changelog')
+    @patch('kiwi_keg.tools.compose_kiwi_description.update_revisions')
+    @patch('os.remove')
+    @patch('kiwi_keg.tools.compose_kiwi_description.get_revision_args')
+    @patch('glob.glob')
+    @patch('kiwi_keg.tools.compose_kiwi_description.SourceInfoGenerator')
+    @patch('kiwi_keg.tools.compose_kiwi_description.ET')
+    @patch('kiwi_keg.tools.compose_kiwi_description.tempfile.TemporaryDirectory')
+    @patch('kiwi_keg.tools.compose_kiwi_description.KegImageDefinition')
+    @patch('kiwi_keg.tools.compose_kiwi_description.KegGenerator')
+    @patch('kiwi_keg.tools.compose_kiwi_description.subprocess.run')
+    @patch('kiwi_keg.tools.compose_kiwi_description.os.mkdir')
+    @patch('os.path.exists')
+    def test_compose_kiwi_description_osc_log(
+        self, mock_path_exists, mock_mkdir, mock_subprocess_run,
+        mock_KegGenerator, mock_KegImageDefinition, mock_TemporaryDirectory,
+        mock_ET, mock_SourceInfoGenerator, mock_glob,
+        mock_get_revision_args, mock_remove, mock_update_revisions,
+        mock_update_changelog
+    ):
+        sys.argv = [
+            sys.argv[0],
+            '--git-recipes',
+            'https://github.com/SUSE-Enceladus/keg-recipes.git',
+            '--image-source',
+            'leap/jeos/15.2',
+            '--git-branch',
+            'develop',
+            '--outdir',
+            'obs_out',
+            '--changelog-format=osc'
+        ]
+        mock_tree = Mock()
+        mock_root = Mock()
+        mock_prefs = Mock()
+        mock_ver = Mock()
+        mock_ET.parse.return_value = mock_tree
+        mock_tree.getroot.return_value = mock_root
+        mock_root.findall.return_value = [mock_prefs]
+        mock_prefs.find.return_value = mock_ver
+        mock_ver.text = '1.1.1'
+        mock_path_exists.side_effect = [False, False, True, True, True, False]
+        image_definition = Mock()
+        mock_KegImageDefinition.return_value = image_definition
+        image_generator = Mock()
+        mock_KegGenerator.return_value = image_generator
+        temp_dir = Mock()
+        mock_TemporaryDirectory.return_value = temp_dir
+        source_info_generator = Mock()
+        mock_SourceInfoGenerator.return_value = source_info_generator
+        mock_glob.return_value = ['obs_out/log_sources_flavor1', 'obs_out/log_sources_flavor2']
+        mock_get_revision_args.return_value = ['-r', 'fake_repo:fake_rev..']
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_subprocess_run.return_value = mock_result
+
+        with patch('builtins.open', create=True):
+            main()
+
+        mock_mkdir.assert_called_once_with('obs_out')
+        assert mock_subprocess_run.call_args_list == [
+            call(
+                [
+                    'git', 'clone', '-b', 'develop',
+                    'https://github.com/SUSE-Enceladus/keg-recipes.git',
+                    temp_dir.name
+                ]
+            ),
+            call(
+                [
+                    'git', '-C', temp_dir.name,
+                    'show', '--no-patch', '--format=%H', 'HEAD'
+                ], capture_output=True, encoding='UTF-8'
+            ),
+            call(
+                [
+                    'generate_recipes_changelog',
+                    '-o', 'obs_out/flavor1.changes.txt',
+                    '-f', 'osc',
+                    '-t', '1.1.2',
+                    '-r', 'fake_repo:fake_rev..',
+                    'obs_out/log_sources_flavor1'
+                ]
+            ),
+            call(
+                [
+                    'generate_recipes_changelog',
+                    '-o', 'obs_out/flavor2.changes.txt',
+                    '-f', 'osc',
+                    '-t', '1.1.2',
+                    '-r', 'fake_repo:fake_rev..',
+                    'obs_out/log_sources_flavor2'
+                ]
+            )
+        ]
+        mock_KegImageDefinition.assert_called_once_with(
+            image_name='leap/jeos/15.2',
+            recipes_roots=[temp_dir.name],
+            track_sources=True,
+            image_version='1.1.2'
+        )
+        mock_KegGenerator.assert_called_once_with(
+            image_definition=image_definition, dest_dir='obs_out', archs=[]
+        )
+        image_generator.create_kiwi_description.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_custom_scripts.assert_called_once_with(
+            overwrite=True
+        )
+        image_generator.create_overlays.assert_called_once_with(
+            disable_root_tar=False, overwrite=True
+        )
+        mock_ET.parse.assert_called_once_with(
+            'config.kiwi'
+        )
+        assert mock_remove.call_args_list == [
+            call('obs_out/log_sources_flavor1'),
+            call('obs_out/log_sources_flavor2')
+        ]
+        source_info_generator.write_source_info.assert_called_once()
+        mock_update_revisions.assert_called_once()
+        assert mock_update_changelog.call_args_list == [
+            call('obs_out/flavor1.changes.txt', 'osc'),
+            call('obs_out/flavor2.changes.txt', 'osc')
+        ]
+
+    def test_compose_kiwi_description_unknown_log_format(self):
+        sys.argv = [
+            sys.argv[0],
+            '--git-recipes',
+            'https://github.com/SUSE-Enceladus/keg-recipes.git',
+            '--image-source',
+            'leap/jeos/15.2',
+            '--git-branch',
+            'develop',
+            '--outdir',
+            'obs_out',
+            '--changelog-format=foo'
+        ]
+        with raises(SystemExit) as sysex:
+            main()
+        assert sysex.value.code == 'Unknown changelog format foo'
 
     @patch('os.path.exists')
     def test_too_many_branch_args(self, mock_path_exists):
@@ -286,17 +578,17 @@ class TestFetchFromKeg:
             update_revisions(repos, tmpdirname)
             assert open(os.path.join(tmpdirname, '_keg_revisions'), 'r').read() == 'fake_repo 1234\n'
 
-    @patch('kiwi_keg.tools.compose_kiwi_description.XMLDescription')
-    def test_image_version_error(self, mock_XMLDescription):
-        xml_data = Mock()
-        preferences = Mock()
-        preferences.get_version.return_value = None
-        xml_data.get_preferences.return_value = [preferences]
-        description = Mock()
-        description.load.return_value = xml_data
-        mock_XMLDescription.return_value = description
+    @patch('kiwi_keg.tools.compose_kiwi_description.ET')
+    def test_image_version_error(self, mock_ET):
+        mock_tree = Mock()
+        mock_root = Mock()
+        mock_prefs = Mock()
+        mock_ET.parse.return_value = mock_tree
+        mock_tree.getroot.return_value = mock_root
+        mock_root.findall.return_value = [mock_prefs]
+        mock_prefs.find.return_value = None
         with raises(SystemExit) as sysex:
-            get_image_version(mock_XMLDescription)
+            get_image_version('fake')
         assert sysex.value.code == 'Cannot determine image version.'
 
     @patch('kiwi_keg.tools.compose_kiwi_description.get_head_commit_hash')
@@ -307,20 +599,18 @@ class TestFetchFromKeg:
         repo = RepoInfo(mock_dir)
         repos = {'repo1': repo}
         with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+
+            with self._caplog.at_level(logging.INFO):
+                parse_revisions(repos)
+                assert 'No _keg_revision file.' in self._caplog.text
+
             with open(os.path.join(tmpdirname, '_keg_revisions'), 'w') as outf:
                 outf.write('repo1 hash1\nrepo2 hash2\n')
-
-            old_wd = os.getcwd()
-            os.chdir(tmpdirname)
 
             with self._caplog.at_level(logging.WARNING):
                 parse_revisions(repos)
                 assert 'Cannot map URL "repo2" to repository.' in self._caplog.text
-
-            os.remove('_keg_revisions')
-            with self._caplog.at_level(logging.WARNING):
-                parse_revisions(repos)
-                assert 'No _keg_revision file.' in self._caplog.text
 
             with open(os.path.join(tmpdirname, '_keg_revisions'), 'w') as outf:
                 outf.write('INVALID')
@@ -328,8 +618,6 @@ class TestFetchFromKeg:
             with raises(SystemExit) as sysex:
                 parse_revisions(repos)
             assert sysex.value.code == 'Malformed revision spec "INVALID".'
-
-            os.chdir(old_wd)
 
     @patch('kiwi_keg.tools.compose_kiwi_description.get_head_commit_hash')
     def test_get_revision_args(self, mock_get_head_commit_hash):
@@ -342,22 +630,90 @@ class TestFetchFromKeg:
         assert repo.head_commit == '5678'
         assert get_revision_args(repos) == ['-r', 'dir1:1234..']
 
-    @patch('kiwi_keg.tools.compose_kiwi_description.Command.run')
-    def test_changelog_prepend(self, mock_run):
+    def test_update_changelog_yaml(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
-            old_wd = os.getcwd()
             os.chdir(tmpdirname)
-            open('changes.yaml', 'w').write('old entry\n')
-            open('changes.yaml.new', 'w').write('new entry\n')
-            update_changelog('changes.yaml', 'changes.yaml.new')
-            assert open('changes.yaml.new', 'r').read() == 'new entry\nold entry\n'
-            os.chdir(old_wd)
+            os.mkdir('out')
+            open('changes.yaml', 'w').write('- change: old entry\n')
+            open('out/changes.yaml', 'w').write('- change: new entry\n')
+            update_changelog('out/changes.yaml', 'yaml')
+            assert open('out/changes.yaml', 'r').read() == '- change: new entry\n- change: old entry\n'
+
+    def test_update_changelog_yaml_to_json(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+            os.mkdir('out')
+            open('changes.yaml', 'w').write('"1.0":\n  - change: old entry\n')
+            open('out/changes.json', 'w').write('{ "1.1": [{"change": "new entry"}] }\n')
+            update_changelog('out/changes.json', 'json')
+            assert json.loads(open('out/changes.json', 'r').read()) == {
+                "1.1": [{"change": "new entry"}],
+                "1.0": [{"change": "old entry"}]
+            }
+
+    def test_update_changelog_json_to_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+            os.mkdir('out')
+            open('changes.json', 'w').write('{ "1.0": [{"change": "old entry"}] }\n')
+            open('out/changes.yaml', 'w').write('"1.1":\n  - change: new entry\n    details: |-\n      details\n      more details\n')
+            update_changelog('out/changes.yaml', 'yaml')
+            assert yaml.safe_load(open('out/changes.yaml', 'r').read()) == {
+                "1.1": [{"change": "new entry", "details": "details\nmore details"}],
+                "1.0": [{"change": "old entry"}]
+            }
+
+    def test_update_changelog_json_to_osc(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+            os.mkdir('out')
+            open('changes.json', 'w').write('{ "1.0": [{"change": "old entry", "date": "2023-05-11T09:41:50"}]}\n')
+            open('out/changes.txt', 'w').write(fake_changes_txt_new)
+            update_changelog('out/changes.txt', 'osc')
+            assert open('out/changes.txt', 'r').read() == fake_changes_txt_merged
+
+    def test_update_changelog_osc_to_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+            os.mkdir('out')
+            open('changes.txt', 'w').write('not convertable')
+            open('out/changes.yaml', 'w').write('- change: new entry\n')
+            update_changelog('out/changes.yaml', 'yaml')
+            assert open('out/changes.yaml', 'r').read() == '- change: new entry\n'
+
+    def test_update_changelog_unsupported_format(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+            os.mkdir('out')
+            open('changes.foo', 'w').write('foo format')
+            open('out/changes.yaml', 'w').write('- change: new entry\n')
+            update_changelog('out/changes.yaml', 'yaml')
+            assert open('out/changes.yaml', 'r').read() == '- change: new entry\n'
+            assert 'Unsupported log format' in self._caplog.text
+
+    def test_update_changelog_no_old_log(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+            update_changelog('out/changes.yaml', 'yaml')
+            assert 'No old log' in self._caplog.text
+
+    def test_update_changelog_multiple_old_logs(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chdir(tmpdirname)
+            open('changes.txt', 'w').write('- some change')
+            open('changes.json', 'w').write('{"1.0.0": [{"change": "old entry"}]}')
+            os.mkdir('out')
+            open('out/changes.json', 'w').write('{"1.0.1": [{"change": "new entry"}]}')
+            update_changelog('out/changes.json', 'json')
+            assert 'More than one format for old log' in self._caplog.text
 
     @patch('kiwi_keg.tools.compose_kiwi_description.parse_revisions')
     @patch('kiwi_keg.tools.compose_kiwi_description.RepoInfo')
-    @patch('kiwi_keg.tools.compose_kiwi_description.Command.run')
+    @patch('tempfile.TemporaryDirectory')
+    @patch('subprocess.run')
     @patch('os.path.exists')
-    def test_no_new_commits(self, mock_path_exists, mock_run, mock_repo_info, mock_parse_revisions):
+    def test_no_new_commits(self, mock_path_exists, mock_run, mock_tempdir,
+                            mock_repo_info, mock_parse_revisions):
         mock_path_exists.return_value = True
         mock_repo_info.has_commits.return_value = False
         with self._caplog.at_level(logging.INFO):
@@ -366,12 +722,11 @@ class TestFetchFromKeg:
             assert 'No repository has new commits.' in self._caplog.text
             assert 'Aborting.' in self._caplog.text
 
-    @patch('kiwi_keg.tools.compose_kiwi_description.Command.run')
-    def test_generate_changelog_error(self, mock_Command_run):
+    @patch('subprocess.run')
+    def test_generate_changelog_error(self, mock_subprocess_run):
         mock_result = Mock()
         mock_result.returncode = 1
-        mock_result.error = 'That went totally wrong'
-        mock_Command_run.return_value = mock_result
+        mock_subprocess_run.return_value = mock_result
         with raises(SystemExit) as sysex:
-            generate_changelog('log_sources', 'changes.yaml', '1.1.1', ['-r', 'fakerev'])
-        assert sysex.value.code == 'Error generating change log: That went totally wrong'
+            generate_changelog('log_sources', 'changes.yaml', 'yaml', '1.1.1', ['-r', 'fakerev'])
+        assert sysex.value.code == 'Error generating change log.'

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ skipsdist = True
 envlist =
     check,
     unit_py3_10,
+    unit_py3_8,
     unit_py3_6,
     devel,
     doc
@@ -24,11 +25,13 @@ allowlist_externals = *
 basepython =
     {check,devel,doc,doc_suse}: python3
     unit_py3_10: python3.10
+    unit_py3_8: python3.8
     unit_py3_6: python3.6
     release: python3.6
 envdir =
     {check,devel,doc,doc_suse}: {toxworkdir}/3
     unit_py3_10: {toxworkdir}/3.10
+    unit_py3_8: {toxworkdir}/3.8
     unit_py3_6: {toxworkdir}/3.6
     release: {toxworkdir}/3.6
 passenv =
@@ -48,7 +51,7 @@ setenv =
     WITH_COVERAGE=yes
 passenv =
     *
-deps = {[testenv]deps}
+deps = -r.virtualenv.dev-requirements-py36.txt
 changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
@@ -58,7 +61,29 @@ commands =
     pytest --no-cov-on-fail --cov=kiwi_keg \
         --cov-report=term-missing \
         --cov-fail-under=100 {posargs}
+        --cov-config .coveragerc_py36
 
+
+# Unit Test run with basepython set to 3.8
+[testenv:unit_py3_8]
+skip_install = True
+usedevelop = True
+setenv =
+    PYTHONPATH={toxinidir}/test
+    PYTHONUNBUFFERED=yes
+    WITH_COVERAGE=yes
+passenv =
+    *
+deps = {[testenv]deps}
+changedir=test/unit
+commands =
+    bash -c 'cd ../../ && ./setup.py develop'
+
+    {envdir}/bin/mypy --ignore-missing-imports {toxinidir}/kiwi_keg/
+
+    pytest --doctest-modules --no-cov-on-fail --cov=kiwi_keg \
+        --cov-report=term-missing \
+        --cov-fail-under=100 {posargs}
 
 # Unit Test run with basepython set to 3.10
 [testenv:unit_py3_10]


### PR DESCRIPTION
Add support for generating json and osc-style ('osc vc') formats to change log generator.
Add config parameter to compose_kiwi_description to select change log format.
Add config parameter to compose_kiwi_description that allows defining a change log entry for new images.
Add support to compose_kiwi_description for converting change log formats when merging old and new change logs (all conversions supported except from osc).