### PR TITLE
Handle namespaces transparently in schema validation

### DIFF
--- a/kiwi_keg/image_schema.py
+++ b/kiwi_keg/image_schema.py
@@ -16,7 +16,7 @@
 # along with keg. If not, see <http://www.gnu.org/licenses/>
 #
 from schema import (
-    Schema, And, Or, Optional,
+    Schema, And, Or, Optional
 )
 from kiwi_keg.annotated_mapping import AnnotatedMapping
 

--- a/kiwi_keg/image_schema.py
+++ b/kiwi_keg/image_schema.py
@@ -16,22 +16,48 @@
 # along with keg. If not, see <http://www.gnu.org/licenses/>
 #
 from schema import (
-    Schema, And, Or, Optional
+    Schema, And, Or, Optional,
 )
 from kiwi_keg.annotated_mapping import AnnotatedMapping
 
 
-class ImageSchema:
+class NamespaceSchema(Schema):
+    def __init__(self, schema, **kwargs):
+        # Generally ignore extra keys; this schema is a sub-set of the full
+        # kiwi schema.
+        kwargs['ignore_extra_keys'] = True
+        super().__init__(schema, **kwargs)
+
+    def validate(self, data):
+        if isinstance(data, dict) and '_namespace' in [x[:10] for x in data.keys()]:
+            namespaces = [x for x in data.keys() if x.startswith('_namespace')]
+            # We create a copy of the input data, remove all namespace keys,
+            # then copy each namespace into the copied dict and validate.
+            # This way namespaces seem invisible and don't have to be accounted
+            # for in the schema, but all namespaced data is validated against
+            # the schema.
+            for ns in namespaces:
+                tmp = data.copy()
+                for del_ns in namespaces:
+                    del tmp[del_ns]
+                tmp.update(data[ns])
+                val = super().validate(tmp)
+        else:
+            val = super().validate(data)
+        return val
+
+
+class ImageSchema():
     def __init__(self):
         self._schema = Schema(
             {
                 Optional('schema'): And(str),
                 Optional('include-paths'): [And(str)],
-                'image': {
+                'image': NamespaceSchema({
                     '_attributes': {
                         'schemaversion': And(str),
                         'name': And(str),
-                        'displayname': And(str),
+                        Optional('displayname'): And(str),
                     },
                     'description': {
                         '_attributes': {
@@ -57,14 +83,14 @@ class ImageSchema:
                             {
                                 '_attributes': {
                                     'profiles': [str],
+                                    Optional('arch'): And(str)
                                 },
                                 'type': {
                                     '_attributes': {
                                         'image': And(str)
                                     }
                                 }
-                            },
-                            ignore_extra_keys=True
+                            }, ignore_extra_keys=True
                         )
                     ],
                     'repository': [
@@ -93,8 +119,8 @@ class ImageSchema:
                                     }
                                 }
                             ],
-                            str: {
-                                'package': [Or(
+                            'package': [
+                                Or(
                                     str,
                                     {
                                         '_attributes': {
@@ -103,11 +129,28 @@ class ImageSchema:
                                         }
                                     },
                                     ignore_extra_keys=True
-                                )]
-                            }
+                                )
+                            ]
                         }
-                    ]
-                },
+                    ],
+                    Optional('drivers'): [
+                        {
+                            Optional('_map_attribute'): And(str),
+                            'file': [
+                                Or(
+                                    str,
+                                    {
+                                        '_attributes': {
+                                            'name': And(str),
+                                            Optional('arch'): Or(str, [str])
+                                        }
+                                    },
+                                    ignore_extra_keys=True
+                                )
+                            ]
+                        }
+                    ],
+                }),
                 Optional('config'): [
                     Or(
                         {

--- a/test/data/broken/images/broken-config/image.yaml
+++ b/test/data/broken/images/broken-config/image.yaml
@@ -14,7 +14,7 @@ image:
   packages:
     - _attributes:
         type: image
-      _some_namespace:
+      _namespace:
         package:
           - _attributes:
               name: some_pkg

--- a/test/data/broken/images/broken-overlay/image.yaml
+++ b/test/data/broken/images/broken-overlay/image.yaml
@@ -14,7 +14,7 @@ image:
   packages:
     - _attributes:
         type: image
-      _some_namespace:
+      _namespace:
         package:
           - _attributes:
               name: some_pkg


### PR DESCRIPTION
This PR removes the expected namespace from the `packages` section from the image dictionary schema and instead handles namespaces transparently in the schema validator by creating a temporary dict in which each namespaced dict is copied into and then validated against the schema. This allows namespaces to be used basically anywhere in the image dict, and also makes them completely optional. It also validates data that was previously in an unexpected namespace before and hence ignored as an extra key.

Also includes minor adjustments (`displayname` is now optional, and an optional `drivers` section is now validated).

Namespaces outside the image dictionary (i.e. in the `config` and `archive` sections) are still mandatory as they are handled differently in the code. Not sure whether it's worth making those optional as well but I'm open to other opinions.