### PR TITLE
Fix new-image-change parameter

### DIFF
--- a/kiwi_keg/tools/compose_kiwi_description.py
+++ b/kiwi_keg/tools/compose_kiwi_description.py
@@ -76,7 +76,7 @@ Options:
         profiles defined. [default: true]
 
     --new-image-change=<changelog_entry>
-        If set, when generating a net new image descriptions, use
+        If set, when generating a net new image description, use
         changelog_entry as the sole entry in the generated change log instead
         of using the full commit history. [default: None]
 

--- a/obs/compose_kiwi_description.service
+++ b/obs/compose_kiwi_description.service
@@ -34,8 +34,8 @@
   <parameter name="generate-multibuild">
     <description>If 'true', generate a _multibuild file if the image definition has profiles defined. [default: true]</description>
   </parameter>
-  <parameter name="new-image-changelog">
-    <description>If set, when generating a net new image descriptions, use changelog_entry as the sole entry in the generated change log instead of using the full commit history. [default: None]</description>
+  <parameter name="new-image-change">
+    <description>If set, when generating a net new image description, use the given string as the sole entry in the generated change log instead of using the full commit history. [default: None]</description>
   </parameter>
   <parameter name="changelog-format">
     <description>Set output format for generated change log. Supported values are 'yaml', 'json', and 'osc'. Existing change logs will be converted if necessary. Conversion from 'osc' is not supported.  [default: json]</description>


### PR DESCRIPTION
A couple of small fixes:

- Fix new-image-change parameter name in OBS .service file.
- Fix typos in new-image-change parameter description in OBS .service file and compose_kiwi_description help.