### PR TITLE
Allow preferences key to be type dict

### DIFF
--- a/kiwi_keg/image_schema.py
+++ b/kiwi_keg/image_schema.py
@@ -75,24 +75,30 @@ class ImageSchema():
                             }
                         }],
                     },
-                    'preferences': [
+                    'preferences': Or(
+                        [
+                            {
+                                'version': And(str),
+                            },
+                            Optional(
+                                {
+                                    '_attributes': {
+                                        'profiles': [str],
+                                        Optional('arch'): And(str)
+                                    },
+                                    'type': {
+                                        '_attributes': {
+                                            'image': And(str)
+                                        }
+                                    }
+                                }, ignore_extra_keys=True
+                            )
+                        ],
                         {
                             'version': And(str),
                         },
-                        Optional(
-                            {
-                                '_attributes': {
-                                    'profiles': [str],
-                                    Optional('arch'): And(str)
-                                },
-                                'type': {
-                                    '_attributes': {
-                                        'image': And(str)
-                                    }
-                                }
-                            }, ignore_extra_keys=True
-                        )
-                    ],
+                        ignore_extra_keys=True
+                    ),
                     'repository': [
                         {
                             '_attributes': {


### PR DESCRIPTION
Allow 'preferences' key of the image dict to be of type dict additionally to type list. In a single-build setup, there is only one preferences section, and having that as a dict makes composing it from different sources more convenient.