### PR TITLE
compose_kiwi_description: fix JSON serialization error

### DIFF
--- a/kiwi_keg/tools/compose_kiwi_description.py
+++ b/kiwi_keg/tools/compose_kiwi_description.py
@@ -314,7 +314,7 @@ def write_changelog(log_file, log_format, changes, append=False):
             yaml.add_representer(str, repr_mstr, Dumper=yaml.SafeDumper)
             yaml.safe_dump(changes, outf, sort_keys=False)
         elif log_format == 'json':
-            json.dump(changes, outf, indent=2)
+            json.dump(changes, outf, indent=2, default=str)
 
 
 def main() -> None:


### PR DESCRIPTION
On recent python version, when converting an existing YAML change log to a JSON one, an exception can occur because when parsing YAML date strings may be created as datetime objects, which json.dump() cannot serialize. Set 'default=str' in json.dump() to auto-convert those to strings.