### PR TITLE
Support newer python versions

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        python-version: ["3.11", "3.12"]
         os: [ubuntu-latest]
         include:
           # Use ubuntu 20.04 for python 3.6 (dropped from later versions)
@@ -16,21 +16,16 @@ jobs:
             os: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Python${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install
+      - name: Install Tox
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox
-      - name: Check code
-        run: |
-          tox -e check
-      - name: Run unit tests
-        run: |
-          tox -e unit
-      - name: Test documentation build
-        run: |
-          tox -e doc
+      - name: Run linter, unit tests and render docs
+        run: tox -e "doc,check,unit_py${PY_VER/./_}"
+        env:
+          PY_VER: ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ build: clean tox
 	sed -ie "s@>=[0-9.]*'@'@g" setup.py
 	# build the sdist source tarball
 	$(python) -m build
+	mv dist/kiwi_keg-${version}.tar.gz dist/keg-${version}.tar.gz
+	rm -f dist/*.whl
 	# restore original setup.py backed up from sed
 	mv setup.pye setup.py
 	# update rpm changelog using reference file
@@ -63,10 +65,8 @@ build: clean tox
 	# copy spec file
 	cp package/$(PKG).spec dist/
 
-pypi: clean tox
-	$(python) setup.py sdist upload
-
 clean: clean_git_attributes
 	$(python) setup.py clean
 	rm -rf doc/build
 	rm -rf doc/dist
+	rm -rf dist

--- a/package/python-kiwi-keg.spec
+++ b/package/python-kiwi-keg.spec
@@ -16,14 +16,13 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
 %if 0%{?suse_version} > 1500
 %bcond_without libalternatives
 %else
 %bcond_with libalternatives
 %endif
 
-%define         skip_python2 1
+%{?sle15_python_module_pythons}
 Name:           python-kiwi-keg
 Version:        2.1.1
 Release:        0
@@ -32,32 +31,41 @@ Summary:        KEG - Image Composition Tool
 License:        GPL-3.0-or-later
 Source:         keg-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  %{python_module Jinja2}
-BuildRequires:  %{python_module Sphinx}
-BuildRequires:  %{python_module base >= 3.6}
 BuildRequires:  %{python_module setuptools}
-BuildRequires:  fdupes
-BuildArch:      noarch
-Requires:       python-Jinja2
-Requires:       python-PyYAML
-Requires:       python-docopt
-Requires:       python-schema
-Requires:       python3-kiwi >= 9.21.21
-%if %python_version_nodots < 37
-Requires:       python-iso8601
+BuildRequires:  %{python_module Sphinx}
+BuildRequires:  %{python_module Jinja2}
+BuildRequires:  %{python_module schema}
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module docopt}
+BuildRequires:  %{python_module PyYAML}
+# On TW the kiwi package is always the latest python default: python3-kiwi
+# On Leap <15.5 and SLES15 <SP5 only one python exists: python3-kiwi
+%if 0%{?suse_version} > 1600 || 0%{?sle_version} < 150500
+BuildRequires:  python3-kiwi
+%else
+BuildRequires:  %{python_module kiwi}
 %endif
+BuildRequires:  fdupes
 %if %{with libalternatives}
-Requires:       alts
 BuildRequires:  alts
+Requires:       alts
 %else
 Requires(post): update-alternatives
 Requires(postun):update-alternatives
 %endif
-%if "%{python_flavor}" == "python3" || "%{python_provides}" == "python3"
+Requires:       python-Sphinx
+Requires:       python-Jinja2
+Requires:       python-schema
+Requires:       python-docopt
+Requires:       python-PyYAML
+%if 0%{?suse_version} > 1600 || 0%{?sle_version} < 150500
+Requires:       python3-kiwi
+%else
+Requires:       python-kiwi
+%endif
 Provides:       python3-kiwi-keg = %version
 Obsoletes:      python3-kiwi-keg < %version
-%endif
-
+BuildArch:      noarch
 %python_subpackages
 
 %description
@@ -77,7 +85,7 @@ more given git repositories that contain keg-recipes source tree. It supports
 auto-generation of change log files from commit history.
 
 %prep
-%setup -q -n keg-%{version}
+%setup -q -n kiwi_keg-%{version}
 
 %build
 # Build Python 3 version

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,7 @@ ignore = E501
 [doc8]
 max-line-length = 90
 verbose = 1
+
+[mypy]
+ignore_missing_imports = True
+no_implicit_optional = False

--- a/tox.ini
+++ b/tox.ini
@@ -10,62 +10,89 @@
 #    $ tox -e doc
 #
 [tox]
+minversion = 3.3.0
+isolated_build = True
 skip_missing_interpreters = True
 skipsdist = True
 envlist =
     check,
-    unit_py36,
-    unit_py37,
-    unit_py38,
-    unit_py39,
-    unit_py310,
-    unit_py311,
-    unit_py312,
+    unit_py3_6,
+    unit_py3_11,
+    unit_py3_12,
     doc
 
 [testenv]
-allowlist_externals = *
+description =
+    {unit_py3_6,unit_py3_11,unit_py3_12}: Unit Test run with basepython set to {basepython}
+    check: Linter Checks
+    doc: Render Docs
+allowlist_externals =
+    bash
+    travis-sphinx
+    cp
+    make
+    rm
+    mv
+    flake8
+    python
+    pytest
 basepython =
-    unit_py36: {env:TOXPYTHON:python3.6}
-    unit_py37: {env:TOXPYTHON:python3.7}
-    unit_py38: {env:TOXPYTHON:python3.8}
-    unit_py39: {env:TOXPYTHON:python3.9}
-    unit_py310: {env:TOXPYTHON:python3.10}
-    unit_py311: {env:TOXPYTHON:python3.11}
-    unit_py312: {env:TOXPYTHON:python3.12}
-    {check,doc,doc_suse,unit}: {env:TOXPYTHON:python3}
+    {check}: python3
+    {doc}: python3
+    unit_py3_6: python3.6
+    unit_py3_11: python3.11
+    unit_py3_12: python3.12
 passenv =
     *
 usedevelop = True
+deps =
+    -r.virtualenv.dev-requirements.txt
+
+
+# Unit Test run with basepython set to 3.6
+[testenv:unit_py3_6]
 setenv =
-    PYTHONPATH={toxinidir}
-    PYTHONUNBUFFERED=yes
-    WITH_COVERAGE=yes
-deps = -r.virtualenv.dev-requirements.txt
-changedir = test/unit
-description = Unit test
+    PYTHONPATH={toxinidir}/test
+changedir=test/unit
 commands =
-    pytest --no-cov-on-fail --cov=kiwi_keg \
-        --cov-report=term-missing \
-        --cov-fail-under=100 {posargs}
+    {[testenv:unit]commands}
+
+
+# Test run with basepython set to 3.11
+[testenv:unit_py3_11]
+setenv =
+    PYTHONPATH={toxinidir}/test
+changedir=test/unit
+commands =
+    {[testenv:unit]commands}
+
+
+# Test run with basepython set to 3.12
+[testenv:unit_py3_12]
+setenv =
+    PYTHONPATH={toxinidir}/test
+changedir=test/unit
+commands =
+    {[testenv:unit]commands}
+
 
 [testenv:unit]
-description = Unit test
+description = Unit Test Base
+skip_install = True
+usedevelop = True
+setenv =
+    PYTHONUNBUFFERED=yes
+    WITH_COVERAGE=yes
+passenv =
+    *
+deps = {[testenv]deps}
+changedir=test/unit
 commands =
-    pytest --no-cov-on-fail --cov=kiwi_keg \
-        --cov-report=term-missing \
-        --cov-fail-under=100 {posargs}
-
-# Unit Test run with system python3
-[testenv:unit_py36]
-description = Unit test Python 3.6
-deps = -r.virtualenv.dev-requirements-py36.txt
-changedir = test/unit
-commands =
+    bash -c 'cd ../../ && python3 setup.py develop'
     pytest --doctest-modules --no-cov-on-fail --cov=kiwi_keg \
-        --cov-report=term-missing \
-        --cov-fail-under=100 {posargs} \
-        --cov-config=.coveragerc_py36
+        --cov-report=term-missing --cov-fail-under=100 \
+        --cov-config .coveragerc {posargs}
+
 
 # Documentation build
 [testenv:doc]
@@ -124,4 +151,4 @@ skip_install = True
 commands =
     flake8 --statistics -j auto --count {toxinidir}/kiwi_keg
     flake8 --statistics -j auto --count {toxinidir}/test/unit
-    mypy --ignore-missing-imports {toxinidir}/kiwi_keg/
+    mypy {toxinidir}/kiwi_keg/


### PR DESCRIPTION
This patch is many fold

1. Update spec file to build against py311 on SLE/Leap

2. Fix tox setup to work with newer python versions

3. Fix sdist tarball layout, for proper submissions to pypi and also according to standard the tarball layout has to match the name of the module. The name of the module is kiwi_keg not keg

4. Don't use source services for packages maintained in SLE, they are not allowed there anyway. Fix the Makefile build target such that a simple "make build" creates all files for proper package submissions

5. Fix github actions workflow to run properly against all tox targets and python versions we want to support, 3.6,3.11,312

You can find package builds available here:

* https://build.opensuse.org/project/show/home:marcus.schaefer:branches:OBS_Maintained:python-kiwi-keg

