### PR TITLE
Doc: Add metadata needed for doc portal

### DIFF
--- a/doc/xml/book.xml
+++ b/doc/xml/book.xml
@@ -2,8 +2,25 @@
       href="file:/usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
       type="application/relax-ng-compact-syntax"
      ?>
-<book xmlns="http://docbook.org/ns/docbook" xml:lang="en" version="5.1" xml:id="keg-reference-guide">
+<book xmlns="http://docbook.org/ns/docbook" xml:lang="en" version="5.1" xmlns:its="http://www.w3.org/2005/11/its" xml:id="keg-reference-guide">
   <title>Keg Reference Guide</title>
+  <meta name="title" its:translate="yes">Keg Reference Guide</meta>
+  <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+  <meta name="description" its:translate="yes">How to create and manage image descriptions for the KIWI appliance builder</meta>
+  <meta name="social-descr" its:translate="yes">Create and manage image descriptions for KIWI</meta>
+  <meta name="task" its:translate="yes">
+    <phrase>Image Building</phrase>
+  </meta>
+  <revhistory xml:id="rh-keg-reference-guide">
+    <revision>
+      <date>2020-07-21</date>
+      <revdescription>
+        <para>
+          Initial release of this document.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
   <info/>
   <preface>
     <title>Preface</title>


### PR DESCRIPTION
### PR creator: Description

For our doc portal to come, all documents published on documentation.suse.com need a certain amount of metadata (to make them filterable, findable etc.). Find the list of metadata that we have agreed on beforehand in our [internal page](https://confluence.suse.com/display/documentation/Adding+metadata+to+all+SUSE+documentation).

I have added the required metadata for the Keg Reference Guide. 

Please review and merge. 